### PR TITLE
Add smoke samples for BB and topology (Stage 2)

### DIFF
--- a/tests/smoke/test_database_samples.py
+++ b/tests/smoke/test_database_samples.py
@@ -1,0 +1,43 @@
+import pytest
+
+import pormake
+
+
+SAMPLE_BBS = [
+    "N3",
+    "N10",
+    "N13",
+    "N114",
+    "N198",
+    "N409",
+    "E41",
+    "N1",
+    "N100",
+    "N200",
+    "N300",
+    "N400",
+    "N500",
+    "N600",
+    "N700",
+    "N710",
+    "E1",
+    "E50",
+    "E110",
+    "E180",
+]
+
+
+@pytest.mark.parametrize("name", SAMPLE_BBS)
+def test_bb_loads(database, name):
+    bb = database.get_bb(name)
+    assert isinstance(bb, pormake.BuildingBlock)
+    assert bb.atoms is not None
+    assert len(bb.atoms) > 0
+
+
+@pytest.mark.parametrize("name", SAMPLE_BBS)
+def test_bb_has_connection_points(database, name):
+    bb = database.get_bb(name)
+    # 'X' atoms denote connection points (per README section 6)
+    n_x = sum(1 for sym in bb.atoms.get_chemical_symbols() if sym == "X")
+    assert n_x > 0, f"BB {name} has no connection points (X atoms)"

--- a/tests/smoke/test_topology_samples.py
+++ b/tests/smoke/test_topology_samples.py
@@ -1,0 +1,41 @@
+import pytest
+
+import pormake
+
+
+SAMPLE_TOPOLOGIES = [
+    "tbo",
+    "pcu",
+    "acs",
+    "ith",
+    "pts",
+    "dia",
+    "nbo",
+    "srs",
+    "ths",
+    "qom",
+    "bcu",
+    "fcu",
+    "lvt",
+    "soc",
+    "rht",
+    "bnn",
+    "lon",
+    "hxg",
+    "hms",
+    "mtn",
+]
+
+
+@pytest.mark.parametrize("name", SAMPLE_TOPOLOGIES)
+def test_topology_loads(database, name):
+    topo = database.get_topo(name)
+    assert isinstance(topo, pormake.Topology)
+    assert topo.n_slots > 0
+
+
+@pytest.mark.parametrize("name", SAMPLE_TOPOLOGIES)
+def test_topology_has_unique_local_structures(database, name):
+    topo = database.get_topo(name)
+    locals_ = topo.unique_local_structures
+    assert len(locals_) > 0, f"Topology {name} has no unique local structures"


### PR DESCRIPTION
## Summary

테스트 인프라 도입 spec의 Stage 2 구현.

- `tests/smoke/test_database_samples.py`: 대표 BB 20개를 parametrize로 로드 + connection point(X atom) 검증 (40 tests)
- `tests/smoke/test_topology_samples.py`: 대표 topology 20개를 parametrize로 로드 + `unique_local_structures` 검증 (40 tests)

Stage 1의 session-scoped `database` fixture를 처음으로 실제 활용. 의존성 업그레이드 시 데이터 자산·파서 회귀를 즉시 감지하는 안전망.

## Sample substitutions (plan 리스트 중 0.2.2 DB에 없던 이름)

- BB: `N800→N710`, `E100→E110`, `E200→E180`
- Topology: `hcb→lvt`, `sql→bnn`

## Test results (로컬)

- `uv run pytest tests/smoke/ -v` → **84 passed** (Stage 1의 4 + BB 40 + topology 40)

## Plan / Spec

- `docs/superpowers/plans/2026-05-28-testing-foundation-stage2.md`
- `docs/superpowers/specs/2026-05-28-testing-foundation-design.md`

## Test plan

- [ ] CI 매트릭스 6칸(3 Python × 2 OS) 전부 녹색
- [ ] 머지 후 main에서 84 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added smoke tests to verify that database building blocks and topology samples load correctly and contain required structural components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sangwon91/PORMAKE/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->