### PR TITLE
Cover high-CN building blocks + mark spec implemented

### DIFF
--- a/docs/superpowers/specs/2026-05-28-testing-foundation-design.md
+++ b/docs/superpowers/specs/2026-05-28-testing-foundation-design.md
@@ -2,7 +2,7 @@
 
 - 작성일: 2026-05-28
 - 작성자: Sangwon Lee (with Claude)
-- 상태: Draft → User Review
+- 상태: 구현 완료 (Stage 1~4 머지: PR #38/#46/#47/#48)
 
 ## 배경
 

--- a/tests/smoke/test_database_samples.py
+++ b/tests/smoke/test_database_samples.py
@@ -24,6 +24,12 @@ SAMPLE_BBS = [
     "E50",
     "E110",
     "E180",
+    # High coordination numbers (parse larger/denser xyz files).
+    "N233",  # CN 7
+    "N103",  # CN 8 (largest BB group)
+    "N401",  # CN 9
+    "N104",  # CN 10
+    "N22",   # CN 24 (432 atoms)
 ]
 
 


### PR DESCRIPTION
## Summary

테스트 인프라 4개 Stage 완료 후 follow-up.

- **CN 커버리지 보강**: Stage 2 smoke가 CN 7/8/9/10/24를 누락했던 것을 보완. `N233`(CN7), `N103`(CN8, 최대 그룹), `N401`(CN9), `N104`(CN10), `N22`(CN24, 432 atoms)를 `SAMPLE_BBS`에 추가 → 더 크고 조밀한 xyz 파싱까지 회귀 감지. Stage 2 final review 권고 반영.
- **spec 상태 갱신**: 설계 문서의 상태 필드를 "Draft → User Review"에서 "구현 완료"로 변경.

## Test results

- `uv run pytest -v` → **131 passed** (이전 121 + BB smoke 10개 추가)

## Test plan

- [ ] CI 매트릭스 6칸 전부 녹색

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing foundation design specification document to reflect completed implementation status with references to merged implementation phases.

* **Tests**
  * Extended database sample coverage by adding new test identifiers to increase parameterized coverage for validation and connection testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sangwon91/PORMAKE/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->