### PR TITLE
docs: add NumPy-style docstrings across src/pormake

### DIFF
--- a/src/pormake/__init__.py
+++ b/src/pormake/__init__.py
@@ -1,3 +1,43 @@
+"""PORMAKE: a builder for porous crystalline materials.
+
+PORMAKE ("porous material maker") assembles periodic reticular
+structures -- primarily Metal-Organic Frameworks (MOFs) and related
+porous crystals -- by placing molecular building blocks onto the
+vertices and edges of an abstract topology (a "net").
+
+The high-level workflow combines an abstract net, real molecular
+fragments, a geometric alignment step, and a unit-cell rescaling step
+to emit a chemically reasonable periodic framework:
+
+1. A :class:`Topology` describes how vertices (nodes) and edge centers
+   connect, read from a ``.cgd`` net file.
+2. A :class:`BuildingBlock` is a molecular fragment read from an
+   ``.xyz`` file, where dummy "X" atoms mark connection points.
+3. A :class:`Database` loads the bundled topology and building-block
+   libraries by name.
+4. A :class:`Locator` aligns a building block onto a topology slot by
+   minimizing the RMSD between connection-point directions.
+5. A :class:`Scaler` rescales the topology unit cell so node-to-node
+   distances match the real building-block sizes.
+6. A :class:`Builder` orchestrates the assembly and produces the final
+   periodic framework, writable to CIF.
+
+Public API
+----------
+Builder
+    Orchestrates assembly of building blocks onto a topology.
+BuildingBlock
+    Molecular fragment with marked connection points.
+Database
+    Loader for the bundled topology/building-block libraries.
+Locator
+    Aligns building blocks onto topology slots by RMSD minimization.
+Scaler
+    Rescales the topology cell to fit the chosen building blocks.
+Topology
+    Abstract net of nodes and edge centers with connectivity.
+"""
+
 from .builder import Builder
 from .building_block import BuildingBlock
 from .database import Database

--- a/src/pormake/builder.py
+++ b/src/pormake/builder.py
@@ -1,3 +1,21 @@
+"""Assemble building blocks onto a topology into a Framework.
+
+This module hosts :class:`Builder`, the orchestrator that turns an
+abstract net (a :class:`~pormake.topology.Topology`) plus a set of
+molecular fragments (:class:`~pormake.building_block.BuildingBlock`)
+into a concrete periodic structure (:class:`~pormake.framework.Framework`).
+
+The build proceeds in stages: orient each node building block onto its
+slot with the :class:`~pormake.locator.Locator` (checking against a
+per-(node-type, bb) minimum RMSD and falling back to a chiral copy when
+a fit is poor); record trivial edge permutations; rescale the topology
+cell to the real building-block sizes with the
+:class:`~pormake.scaler.Scaler`; relocate and translate the nodes onto
+the scaled positions; lay edge linkers along the scaled edges; then find
+all bonds, drop the "X" connection-point atoms while fusing the bonds
+they implied, and wrap everything into a Framework.
+"""
+
 from collections import defaultdict
 
 import numpy as np
@@ -11,7 +29,37 @@ from .scaler import Scaler
 
 # bb: building block.
 class Builder:
+    """Orchestrate assembly of a framework from blocks and a topology.
+
+    Holds the two pluggable strategy objects the assembly depends on --
+    a :class:`~pormake.locator.Locator` for orienting building blocks
+    onto slots and a :class:`~pormake.scaler.Scaler` for resizing the
+    topology cell -- and exposes :meth:`build` (and the per-type
+    convenience wrappers) to run the full pipeline. Keeping locator and
+    scaler injectable lets callers swap matching/scaling behavior without
+    touching the orchestration logic.
+
+    Parameters
+    ----------
+    locator : Locator, optional
+        Strategy for finding the best orientation and permutation of a
+        building block on a slot. A default :class:`Locator` is created
+        when omitted.
+    scaler : Scaler, optional
+        Strategy for rescaling the topology unit cell to match real
+        building-block sizes. A default :class:`Scaler` is created when
+        omitted.
+
+    Attributes
+    ----------
+    locator : Locator
+        The orientation/permutation matcher used during the build.
+    scaler : Scaler
+        The cell-rescaling strategy used during the build.
+    """
+
     def __init__(self, locator=None, scaler=None):
+        """Store the locator and scaler, creating defaults if needed."""
         if locator is None:
             self.locator = Locator()
         else:
@@ -23,14 +71,36 @@ class Builder:
             self.scaler = scaler
 
     def make_bbs_by_type(self, topology, node_bbs, edge_bbs=None):
-        """
-        Make bbs for Builder.build by node and edgy type.
+        """Build the per-slot building-block list from type maps.
 
-        Args:
-            node_bbs: dict of list like containing node building blocks.
-                The key is the type of node (integer).
-            edge_bbs: dict contrainig edge building blocks. The key is the
-                type of edge (tuple of two interges).
+        Expands compact, type-keyed dictionaries into the dense
+        slot-indexed list that :meth:`build` expects, copying each
+        building block so every slot owns an independent instance.
+        Specifying blocks by type (rather than per slot) is the
+        ergonomic way to describe a structure, since all nodes of the
+        same type and all edges of the same type usually share a block.
+        Edge types absent from ``edge_bbs`` are logged and left empty
+        (``None``), producing direct node-to-node bonds.
+
+        Parameters
+        ----------
+        topology : Topology
+            Topology whose slots are being populated; supplies the node
+            and edge indices and their types.
+        node_bbs : dict
+            Maps a node type (int) to the building block to place on
+            every node of that type.
+        edge_bbs : dict, optional
+            Maps an edge type (a tuple of two ints) to the linker
+            building block for those edges. A value of ``None`` for a
+            type leaves those edges empty. Defaults to no edge blocks.
+
+        Returns
+        -------
+        list
+            Length ``topology.n_slots`` list whose entry ``i`` is the
+            (copied) building block for slot ``i``, or ``None`` for empty
+            edge slots.
         """
         bbs = [None] * topology.n_slots
 
@@ -60,25 +130,84 @@ class Builder:
         return bbs
 
     def build_by_type(self, topology, node_bbs, edge_bbs=None, **kwargs):
+        """Assemble a framework from type-keyed building-block maps.
+
+        Convenience wrapper that turns the type-keyed ``node_bbs`` and
+        ``edge_bbs`` dictionaries into a per-slot list via
+        :meth:`make_bbs_by_type` and forwards it to :meth:`build`. This
+        is the usual public entry point for users who think in terms of
+        node and edge *types* rather than individual slots.
+
+        Parameters
+        ----------
+        topology : Topology
+            Net the framework is assembled on.
+        node_bbs : dict
+            Maps node type (int) to its building block.
+        edge_bbs : dict, optional
+            Maps edge type (tuple of two ints) to its linker building
+            block. Defaults to no edge blocks.
+        **kwargs
+            Forwarded to :meth:`build` (e.g. ``accuracy``, ``wrap``,
+            ``permutations``).
+
+        Returns
+        -------
+        Framework
+            The assembled framework.
+        """
         bbs = self.make_bbs_by_type(topology, node_bbs, edge_bbs)
         return self.build(topology, bbs, **kwargs)
 
     def build(self, topology, bbs, permutations=None, **kwargs):
-        """
-        The node_bbs must be given with proper order.
-        Same as node type order in topology.
+        """Assemble a framework from a per-slot list of building blocks.
 
-        Args:
-            topology:
+        Runs the full assembly pipeline. For each node slot it finds the
+        best orientation and connection-point permutation via the
+        locator, comparing the achieved RMSD against a cached minimum for
+        the (node type, building block) pair and retrying with higher
+        accuracy and, if needed, a chiral copy of the block when the fit
+        is more than 1% above that minimum. Edge slots are recorded with
+        a trivial permutation. The topology cell is then scaled to the
+        real block sizes, nodes are relocated and translated onto the
+        scaled positions, and edge linkers are laid along the scaled
+        edges. Finally all intra- and inter-block bonds are collected,
+        the "X" connection-point atoms are removed while the bonds they
+        implied are fused, and the result is returned as a Framework.
 
-            bbs: a list like obejct containing building blocks.
-                bbs[i] contains a bb for node[i] if i in topology.node_indices
-                or edge[i] if i in topology.edge_indices.
+        Parameters
+        ----------
+        topology : Topology
+            Net to assemble on. Node building blocks must correspond to
+            the topology's node-type ordering.
+        bbs : list
+            Length ``topology.n_slots`` sequence where ``bbs[i]`` is the
+            building block for node ``i`` (if ``i`` is a node index) or
+            edge ``i`` (if an edge index). ``None`` leaves an edge empty.
+        permutations : dict, optional
+            Maps a slot index to a pre-determined connection-point
+            permutation, bypassing the locator's search for that slot.
+            Defaults to no pre-set permutations.
+        **kwargs
+            ``accuracy`` : int
+                Euler-angle grid resolution for high-accuracy
+                relocation (``max_n_slices``); default 6.
+            ``wrap`` : bool
+                Whether to wrap the framework into the unit cell;
+                default ``True``.
 
-            permutations:
+        Returns
+        -------
+        Framework
+            The assembled periodic framework, with bonds, bond types,
+            and build metadata in ``info``.
 
-        Return:
-            Framework object.
+        Raises
+        ------
+        Exception
+            If a node placement yields an RMSD below 99% of the cached
+            minimum (with that minimum above ``1e-3``), indicating the
+            minimum RMSD was computed incorrectly.
         """
 
         # Parse keyword arguments.
@@ -288,12 +417,23 @@ class Builder:
 
         # Thie helpers are so verbose. Anoying.
         def find_matched_atom_indices(e):
-            """
-            Inputs:
-                e: Edge index.
+            """Return the two connection-point atoms an edge bonds to.
 
-            External variables:
-                original_topology, located_bbs, permutations.
+            For edge ``e``, locate within each adjacent node block the
+            connection-point atom that faces the edge, so a linker can be
+            bonded to it. Reads the enclosing-scope variables
+            ``original_topology``, ``located_bbs``, and ``permutations``.
+
+            Parameters
+            ----------
+            e : int
+                Edge slot index in the (unscaled) topology.
+
+            Returns
+            -------
+            a1, a2 : int
+                Atom indices, within each neighboring node block, of the
+                connection points matched to this edge's two ends.
             """
             topology = original_topology
 
@@ -329,10 +469,26 @@ class Builder:
             return a1, a2
 
         def calc_image(ni, nj, invc):
-            """
-            Calculate image number.
-            External variables:
-                topology.
+            """Compute the periodic image offset between two neighbors.
+
+            Determine the integer unit-cell translation separating the
+            two node ends of an edge, so an edge that wraps across a cell
+            boundary is placed correctly. Reads the enclosing-scope
+            ``topology``.
+
+            Parameters
+            ----------
+            ni, nj : Neighbor
+                The two neighbor records (node ends) of the edge.
+            invc : numpy.ndarray
+                Inverse of the topology cell matrix, used to convert the
+                Cartesian offset into fractional (image) units.
+
+            Returns
+            -------
+            numpy.ndarray
+                The ``(3,)`` periodic image vector (integer-valued) of
+                ``nj`` relative to ``ni``.
             """
             # Calculate image.
             # d = d_{ij}
@@ -474,6 +630,12 @@ class Builder:
             count += 1
 
         def is_X(i):
+            """Return whether atom ``i`` is an "X" connection point.
+
+            Reads the enclosing-scope ``framework_atoms``; used to
+            classify bonds while fusing and removing the dummy
+            connection-point atoms.
+            """
             return framework_atoms[i].symbol == "X"
 
         XX_bonds = []

--- a/src/pormake/building_block.py
+++ b/src/pormake/building_block.py
@@ -1,3 +1,12 @@
+"""Molecular building blocks placed onto topology slots.
+
+This module defines :class:`BuildingBlock`, the chemical "piece" that
+PORMAKE positions at the nodes and edges of an abstract net. Each block
+carries connection points (``X`` atoms) that mark where it bonds to its
+neighbours; the :class:`~pormake.locator.Locator` aligns those points to
+a slot's local structure and the :class:`~pormake.builder.Builder` fuses
+the placed blocks into a periodic framework.
+"""
 import copy
 
 import ase
@@ -19,7 +28,54 @@ from .utils import (  # covalent_neighbor_list,
 
 
 class BuildingBlock:
+    """Represent a molecular fragment placed onto a topology slot.
+
+    A building block is one of the two raw ingredients PORMAKE
+    assembles into a framework (the other being the abstract
+    ``Topology``). It is read from an ``.xyz`` file in which a few
+    atoms carry the special symbol ``"X"``; these *connection points*
+    mark where the fragment bonds to its neighbours. The geometric
+    arrangement of those connection points around their centroid is
+    the building block's ``LocalStructure``, the quantity the
+    ``Locator`` rotates and permutes to match a topology slot's local
+    structure with minimal RMSD.
+
+    Building blocks come in two flavours determined purely by how many
+    connection points they have. A 2-connected fragment is an *edge*
+    (a linker that sits on a topology edge-center); anything with three
+    or more connection points is a *node* that fills a vertex slot.
+    Whether the block contains a metal further distinguishes inorganic
+    nodes from organic linkers when reconstructing a MOF.
+
+    Parameters
+    ----------
+    bb_file : str
+        Path to the building block ``.xyz`` file. The file's comment
+        line is parsed for the block name, connection-point indices,
+        and any pre-recorded bond list / bond types.
+    local_structure_func : callable, optional
+        Custom normalization applied to the connection points when
+        building the ``LocalStructure``. When ``None`` the default
+        unit-direction normalization of ``LocalStructure`` is used.
+        Supplying a different function lets callers experiment with
+        alternative ways of describing slot geometry.
+
+    Attributes
+    ----------
+    atoms : ase.Atoms
+        All atoms of the fragment, including the ``"X"`` connection
+        points.
+    name : str
+        Identifier of the building block, taken from the ``.xyz``
+        comment line.
+    connection_point_indices : numpy.ndarray
+        Indices into ``atoms`` of the ``"X"`` connection points.
+    local_structure_func : callable or None
+        The normalization function forwarded to ``LocalStructure``.
+    """
+
     def __init__(self, bb_file, local_structure_func=None):
+        """Read a building block from an ``.xyz`` file."""
         self.atoms = read_budiling_block_xyz(bb_file)
         self.name = self.atoms.info["name"]
         self.connection_point_indices = np.array(self.atoms.info["cpi"])
@@ -31,14 +87,54 @@ class BuildingBlock:
         self.check_bonds()
 
     def copy(self):
+        """Return an independent deep copy of this building block.
+
+        Used whenever the assembly pipeline needs to place several
+        instances of the same fragment onto different slots without
+        the per-slot rotations/translations leaking back into the
+        shared template.
+
+        Returns
+        -------
+        BuildingBlock
+            A deep copy whose ``atoms`` can be mutated freely.
+        """
         return copy.deepcopy(self)
 
     def make_chiral_building_block(self):
+        """Return the mirror image of this building block.
+
+        Inverts every atomic position through the origin, producing
+        the opposite-handed enantiomer. This gives the ``Locator`` a
+        second candidate to try when a fragment's connection points
+        cannot be aligned onto a slot by rotation alone (some slots
+        require a reflected building block to reach a low RMSD).
+
+        Returns
+        -------
+        BuildingBlock
+            A copy with all positions negated.
+        """
         _bb = self.copy()
         _bb.atoms.set_positions(-_bb.atoms.get_positions())
         return _bb
 
     def local_structure(self):
+        """Build the ``LocalStructure`` of the connection points.
+
+        Wraps the connection-point positions in a ``LocalStructure``,
+        i.e. the normalized set of unit direction vectors from their
+        centroid. This is the geometric "currency" the ``Locator``
+        aligns against a topology slot's local structure to decide
+        how the fragment should be oriented.
+
+        Returns
+        -------
+        LocalStructure
+            Local structure of the ``"X"`` connection points, carrying
+            their original indices and using
+            ``local_structure_func`` for normalization when provided.
+        """
         connection_points = self.atoms[self.connection_point_indices].positions
         return LocalStructure(
             connection_points,
@@ -47,8 +143,19 @@ class BuildingBlock:
         )
 
     def set_centroid(self, centroid):
-        """
-        Set centroid of connection points.
+        """Rigidly translate the fragment to a new centroid.
+
+        Shifts every atom so that the centroid of the connection
+        points lands exactly on ``centroid``, leaving the internal
+        geometry and orientation untouched. The ``Builder`` calls this
+        to drop an already-oriented building block onto the location of
+        its target topology slot.
+
+        Parameters
+        ----------
+        centroid : array_like of shape (3,)
+            The Cartesian position the connection-point centroid
+            should be moved to.
         """
         positions = self.atoms.positions
         # Move centroid to zero.
@@ -59,25 +166,86 @@ class BuildingBlock:
 
     @property
     def centroid(self):
+        """Geometric anchor of the building block.
+
+        The mean of the connection-point positions. This is the point
+        the ``Builder`` aligns with a topology slot's location when
+        translating a located fragment into place, and the origin
+        about which ``Locator`` rotations are applied. It is *not* the
+        centroid of all atoms, only of the ``"X"`` connection points.
+
+        Returns
+        -------
+        numpy.ndarray of shape (3,)
+            Mean position of the connection points.
+        """
         centroid = np.mean(self.connection_points, axis=0)
         return centroid
 
     @property
     def connection_points(self):
+        """Cartesian positions of the ``"X"`` connection points.
+
+        These are the atoms that bond to neighbouring building blocks;
+        their layout defines the slot the fragment can fill and feeds
+        both ``centroid`` and ``local_structure``.
+
+        Returns
+        -------
+        numpy.ndarray of shape (n_connection_points, 3)
+            Positions of the connection-point atoms.
+        """
         return self.atoms[self.connection_point_indices].positions
 
     @property
     def n_connection_points(self):
+        """Number of connection points (the fragment's coordination).
+
+        This count must equal the coordination number of any topology
+        slot the fragment is placed on, and it decides whether the
+        fragment is treated as an edge or a node.
+
+        Returns
+        -------
+        int
+            Count of ``"X"`` connection points.
+        """
         return len(self.connection_point_indices)
 
     @property
     def lengths(self):
+        """Distances from the centroid to each connection point.
+
+        These radii feed the ``Scaler``, which rescales the topology
+        unit cell so node-to-node distances match the real sizes of
+        the chosen building blocks.
+
+        Returns
+        -------
+        numpy.ndarray of shape (n_connection_points,)
+            Euclidean distance of each connection point from
+            ``centroid``.
+        """
         dists = self.connection_points - self.centroid
         norms = np.linalg.norm(dists, axis=1)
         return norms
 
     @property
     def has_metal(self):
+        """Whether the fragment contains a metal-like element.
+
+        Distinguishes inorganic nodes from organic linkers, which the
+        pipeline (and the inverse decomposer) needs when classifying
+        building blocks. If a value has been explicitly assigned via
+        the setter that cached value is returned; otherwise membership
+        is computed against ``METAL_LIKE``.
+
+        Returns
+        -------
+        bool
+            ``True`` if any atom symbol is in ``METAL_LIKE`` (or the
+            cached override is truthy).
+        """
         if self._has_metal is None:
             inter = set(self.atoms.symbols) & set(METAL_LIKE)
             return len(inter) != 0
@@ -87,6 +255,23 @@ class BuildingBlock:
 
     @has_metal.setter
     def has_metal(self, v):
+        """Override the cached metal-presence flag.
+
+        Lets callers force the classification (e.g. when the automatic
+        ``METAL_LIKE`` membership test is wrong for an unusual
+        fragment). Passing ``None`` clears the override so the
+        property falls back to automatic detection.
+
+        Parameters
+        ----------
+        v : bool or None
+            The forced value, or ``None`` to restore auto-detection.
+
+        Raises
+        ------
+        Exception
+            If ``v`` is neither a ``bool`` nor ``None``.
+        """
         if isinstance(v, bool) or (v is None):
             logger.debug("New value is assigned for self._has_metal.")
             self._has_metal = v
@@ -95,14 +280,47 @@ class BuildingBlock:
 
     @property
     def is_edge(self):
+        """Whether this fragment is an edge linker.
+
+        A 2-connected building block is placed on a topology
+        edge-center, acting as a linker between two nodes.
+
+        Returns
+        -------
+        bool
+            ``True`` if there are exactly two connection points.
+        """
         return self.n_connection_points == 2
 
     @property
     def is_node(self):
+        """Whether this fragment fills a topology node (vertex) slot.
+
+        Any building block that is not an edge (i.e. not 2-connected)
+        is treated as a node occupying a vertex of the net.
+
+        Returns
+        -------
+        bool
+            ``True`` if the fragment has other than two connection
+            points.
+        """
         return not self.is_edge
 
     @property
     def bonds(self):
+        """Atom-index pairs describing the fragment's bonds.
+
+        Used when writing the assembled framework so that bond
+        connectivity is preserved in the output CIF. The bond list is
+        computed lazily from interatomic distances if it was not
+        supplied in the source ``.xyz`` file.
+
+        Returns
+        -------
+        numpy.ndarray of shape (n_bonds, 2)
+            Pairs ``(i, j)`` of bonded atom indices.
+        """
         if self._bonds is None:
             self.calculate_bonds()
 
@@ -110,6 +328,17 @@ class BuildingBlock:
 
     @property
     def bond_types(self):
+        """Bond-order label for each entry in ``bonds``.
+
+        Parallel to ``bonds``; entries are single-bond markers
+        (``"S"``) when bonds are auto-computed. Carried through to the
+        output CIF alongside the bond list.
+
+        Returns
+        -------
+        list of str
+            One bond-type string per bond.
+        """
         if self._bond_types is None:
             self.calculate_bonds()
 
@@ -117,9 +346,23 @@ class BuildingBlock:
 
     @property
     def n_atoms(self):
+        """Total number of atoms, including connection points.
+
+        Returns
+        -------
+        int
+            Length of the underlying ``ase.Atoms`` object.
+        """
         return len(self.atoms)
 
     def check_bonds(self):
+        """Warn about atoms that participate in no bond.
+
+        Run at construction time as a sanity check: every atom in a
+        well-formed fragment should appear in at least one bond. Any
+        dangling atoms are logged as a warning (this commonly flags a
+        malformed ``.xyz`` or a connection point that failed to bond).
+        """
         if self._bonds is None:
             self.calculate_bonds()
 
@@ -140,6 +383,15 @@ class BuildingBlock:
             # logger.warning("Make new bond for X.")
 
     def calculate_bonds(self):
+        """Infer bonds from interatomic distances.
+
+        Populates ``_bonds`` and ``_bond_types`` when the source file
+        carried no explicit connectivity. A pair of atoms is bonded
+        when their separation is below 1.2 times the sum of their
+        natural covalent cutoffs; every inferred bond is labelled a
+        single bond (``"S"``). Each unordered pair is recorded once
+        (with ``i < j``).
+        """
         logger.debug("Start calculating bonds.")
 
         r = self.atoms.positions
@@ -162,13 +414,43 @@ class BuildingBlock:
         self._bond_types = ["S" for _ in self.bonds]
 
     def view(self, *args, **kwargs):
+        """Open the fragment in an interactive ASE viewer.
+
+        Convenience wrapper for visual inspection of the atoms (e.g.
+        to confirm connection-point placement) during interactive
+        work.
+
+        Parameters
+        ----------
+        *args, **kwargs
+            Forwarded verbatim to ``ase.visualize.view``.
+        """
         ase.visualize.view(self.atoms, *args, **kwargs)
 
     def __repr__(self):
+        """Return a one-line summary for debugging.
+
+        Returns
+        -------
+        str
+            The building block name and its number of connection
+            points.
+        """
         msg = "BuildingBlock: {}, # of connection points: {}".format(
             self.name, self.n_connection_points
         )
         return msg
 
     def write_cif(self, filename):
+        """Write the fragment to a CIF file.
+
+        Exports the atoms together with their bond list and bond
+        types, so a single building block can be inspected on its own
+        outside an assembled framework.
+
+        Parameters
+        ----------
+        filename : str
+            Destination path for the CIF file.
+        """
         write_molecule_cif(filename, self.atoms, self.bonds, self.bond_types)

--- a/src/pormake/database.py
+++ b/src/pormake/database.py
@@ -1,3 +1,11 @@
+"""Access to the bundled topology and building-block libraries.
+
+This module exposes :class:`Database`, the lookup layer that lets users
+fetch reference nets and molecular fragments by name instead of dealing
+with raw ``.cgd``/``.xyz`` files. It is usually the first object a caller
+touches: the topologies and building blocks it returns are the inputs the
+:class:`~pormake.builder.Builder` assembles into a framework.
+"""
 import pickle
 from pathlib import Path
 
@@ -7,7 +15,45 @@ from .topology import Topology
 
 
 class Database:
+    """Load the bundled topology and building-block libraries by name.
+
+    PORMAKE ships a ``database/`` directory containing abstract nets as
+    ``.cgd`` files (cached as ``.pickle`` for fast reloading) and
+    molecular building blocks as ``.xyz`` files. ``Database`` is the
+    central registry that resolves names to fully constructed
+    :class:`~pormake.topology.Topology` and
+    :class:`~pormake.building_block.BuildingBlock` objects, so the rest
+    of the assembly pipeline can request components by short name
+    instead of file path.
+
+    By default it points at the packaged ``database/topologies`` and
+    ``database/bbs`` folders, but custom directories may be supplied to
+    work with user-provided libraries.
+
+    Parameters
+    ----------
+    topo_dir : str or pathlib.Path, optional
+        Directory holding topology ``.cgd``/``.pickle`` files. If
+        ``None``, the bundled ``database/topologies`` directory is used.
+    bb_dir : str or pathlib.Path, optional
+        Directory holding building-block ``.xyz`` files. If ``None``,
+        the bundled ``database/bbs`` directory is used.
+
+    Attributes
+    ----------
+    topo_dir : pathlib.Path
+        Resolved directory of topology files.
+    bb_dir : pathlib.Path
+        Resolved directory of building-block files.
+
+    Raises
+    ------
+    Exception
+        If either resolved directory does not exist.
+    """
+
     def __init__(self, topo_dir=None, bb_dir=None):
+        """Resolve and validate the topology/building-block directories."""
         db_path = Path(__file__).parent / "database"
 
         if topo_dir is None:
@@ -35,28 +81,56 @@ class Database:
             raise Exception(message)
 
     def _get_topology_list(self):
+        """Return the names of all topologies in ``topo_dir``.
+
+        Returns
+        -------
+        list of str
+            Stems (names without extension) of every ``.cgd`` file in
+            the topology directory.
+        """
         return [p.stem for p in self.topo_dir.glob("*.cgd")]
 
     @property
     def topology_list(self):
+        """list of str: Names of all available topologies."""
         return self._get_topology_list()
 
     @property
     def topo_list(self):
+        """list of str: Convenience alias for :attr:`topology_list`."""
         return self._get_topology_list()
 
     def _get_bb_list(self):
+        """Return the names of all building blocks in ``bb_dir``.
+
+        Returns
+        -------
+        list of str
+            Stems (names without extension) of every ``.xyz`` file in
+            the building-block directory.
+        """
         return [p.stem for p in self.bb_dir.glob("*.xyz")]
 
     @property
     def building_block_list(self):
+        """list of str: Names of all available building blocks."""
         return self._get_bb_list()
 
     @property
     def bb_list(self):
+        """list of str: Convenience alias for :attr:`building_block_list`."""
         return self._get_bb_list()
 
     def serialize(self):
+        """Pre-pickle every bundled topology for fast later loading.
+
+        Builds each topology from its ``.cgd`` file and writes a
+        matching ``.pickle`` next to it. Because parsing a ``.cgd`` net
+        is comparatively slow, pickling the libraries up front lets
+        :meth:`get_topology` reload them quickly on subsequent runs.
+        Topologies that fail to parse are skipped with a debug message.
+        """
         print("Database serialization starts.")
         n_topos = len(self.topo_list)
         for i, name in enumerate(self.topo_list, start=1):
@@ -77,6 +151,28 @@ class Database:
             print("\rProgress: %.1f %% (%d/%d)" % (percent, i, n_topos), end="")
 
     def get_topology(self, name):
+        """Load a topology by name, using the pickle cache when present.
+
+        Attempts to load the pre-pickled topology first; if no pickle
+        exists, the ``.cgd`` file is parsed into a
+        :class:`~pormake.topology.Topology` and the result is cached as
+        a ``.pickle`` for next time.
+
+        Parameters
+        ----------
+        name : str
+            Topology name without extension (e.g. ``"pcu"``).
+
+        Returns
+        -------
+        pormake.topology.Topology
+            The requested topology.
+
+        Raises
+        ------
+        Exception
+            If the topology cannot be loaded from pickle or ``.cgd``.
+        """
         # Add .cgd to the topology name.
         pickle_path = self.topo_dir / (name + ".pickle")
         try:
@@ -104,9 +200,28 @@ class Database:
         return topo
 
     def get_topo(self, name):
+        """Convenience alias for :meth:`get_topology`."""
         return self.get_topology(name)
 
     def get_building_block(self, name):
+        """Load a building block by name from the ``.xyz`` library.
+
+        Parameters
+        ----------
+        name : str
+            Building-block name (with or without ``.xyz`` extension);
+            only the stem is used to locate the file.
+
+        Returns
+        -------
+        pormake.building_block.BuildingBlock
+            The requested building block.
+
+        Raises
+        ------
+        Exception
+            If the building block cannot be loaded.
+        """
         # Add .xyz to the building block name.
         name = Path(name).stem + ".xyz"
 
@@ -122,4 +237,5 @@ class Database:
         return bb
 
     def get_bb(self, name):
+        """Convenience alias for :meth:`get_building_block`."""
         return self.get_building_block(name)

--- a/src/pormake/experimental/decomposer/__init__.py
+++ b/src/pormake/experimental/decomposer/__init__.py
@@ -1,5 +1,10 @@
-"""Experimental MOF Decomposer module. It's refactored from the legacy code used
-in the PORMAKE paper. It is an experimental feature and may not be stable.
+"""Decompose an existing MOF back into building blocks.
+
+This experimental subpackage runs the build pipeline in reverse: given a
+finished MOF crystal it identifies the metal nodes and organic linkers,
+cuts the bonds between them, and emits capped fragments that can be reused
+as PORMAKE building blocks. It is refactored from the legacy code used in
+the PORMAKE paper and may not be stable.
 """
 import collections
 import copy
@@ -13,10 +18,13 @@ from ...utils import METAL_LIKE, covalent_neighbor_list
 
 
 def hash_atoms(atoms: ase.Atoms, complexity: int = 6):
-    """Hashes an ase.Atoms object into a unique integer. The hash is based on
-    the adjacency matrix of the covalent bonds and the atomic numbers of the
-    atoms. The hash is invariant to the order of the atoms in the atoms object.
-    It is an experimental feature and may not be stable.
+    """Hash an ase.Atoms object into a near-unique integer fingerprint.
+
+    The fingerprint is built from the covalent-bond adjacency matrix and
+    the atomic numbers, making it invariant to atom ordering. It lets the
+    decomposer group chemically identical fragments so that recurring
+    building blocks are recognised as the same piece. Experimental and may
+    not be stable.
 
     Parameters
     ----------
@@ -47,10 +55,12 @@ def hash_atoms(atoms: ase.Atoms, complexity: int = 6):
 
 
 def estimate_atoms_dimension(atoms: ase.Atoms):
-    """Estimates the dimension of the atoms object in periodic system. Is is
-    used to estimate the dimension of MOFs or building blocks in the MOF. For
-    current version of PORMAKE, only building blocks with 0 dimension are
-    supported. It is an experimental feature and may not be stable.
+    """Estimate the periodic dimensionality (0-3) of an atoms object.
+
+    Used to tell a finite molecular building block (0D) apart from a chain
+    (1D), layer (2D), or framework (3D); the current PORMAKE only supports
+    0D building blocks, so this guards fragment merging during
+    decomposition. Experimental and may not be stable.
 
     Parameters
     ----------
@@ -139,38 +149,80 @@ def remove_pbc_cuts(atoms):
 
 
 class MOFDecomposer:
+    """Decompose an existing MOF back into building blocks.
+
+    This is the inverse of the PORMAKE assembly pipeline: instead of
+    placing building blocks onto a topology to grow a framework, it
+    reads an assembled MOF from a CIF and cuts it apart into the
+    inorganic nodes and organic linkers it was built from. The metal
+    coordination bonds are treated as the seams between fragments;
+    severing them yields the individual building blocks, and the
+    severed bonds (the *connecting bonds*) record where each fragment
+    reconnected to its neighbours. Those break points are later capped
+    with dummy ``X`` atoms so the extracted fragments carry the same
+    connection-point convention as native PORMAKE building blocks.
+
+    It is an experimental feature and may not be stable.
+
+    Parameters
+    ----------
+    cif : str
+        The path to the CIF file of the MOF.
+    X_type : str
+        The symbol used for the dummy connection-point atom appended at
+        each break point. It is used to identify the connection sites.
+        Default is ``'X'``.
+
+    Attributes
+    ----------
+    atoms : ase.Atoms
+        The MOF structure read from the CIF (mutated in place by
+        ``cleanup``).
+    name : str
+        The CIF file stem, used to name the structure.
+    bb_found : bool
+        Whether building blocks and connecting bonds have been
+        computed yet (drives lazy evaluation).
+    X_type : str
+        Symbol used for the connection-point dummy atoms.
+
+    TODO:
+        * Custom bond information (connectivity and bond types).
+    """
+
     def __init__(self, cif, X_type='X'):
-        """MOF decomposer class. It is an experimental feature and may not be
-        stable.
-
-        TODO:
-            * Custom bond information (connectivity and bond types).
-
-        Parameters
-        ----------
-        cif : str
-            The path to the CIF file of the MOF.
-        X_type : str
-            The symbol of the X atom. It is used to identify the connection
-            sites. Default is 'X'.
-        """
+        """Read the MOF from a CIF file."""
         self.atoms = ase.io.read(cif)
         self.name = Path(cif).stem
         self.bb_found = False
         self.X_type = X_type
 
     def view(self, *args, **kwargs):
+        """Open the MOF structure in an interactive ASE viewer.
+
+        Convenience helper for visually inspecting the loaded
+        structure, e.g. before or after ``cleanup``.
+
+        Parameters
+        ----------
+        *args, **kwargs
+            Forwarded verbatim to ``ase.visualize.view``.
+        """
         ase.visualize.view(self.atoms, *args, **kwargs)
 
     def cleanup(self, remove_interpenetration=True):
-        """Removes interpenetration and isolated molecules from the MOF.
-        It is an experimental feature and may not be stable.
+        """Remove interpenetration and isolated molecules from the MOF.
+
+        A clean single framework is a precondition for reliable
+        decomposition, so this prunes the structure down to the relevant
+        connected component(s) before fragments are searched for.
+        Experimental and may not be stable.
 
         Parameters
         ----------
         remove_interpenetration : bool
-            If True, removes interpenetration. If False, removes only isolated
-            molecules.
+            If True, keep only the largest framework. If False, drop solvent
+            and isolated molecules but keep equal-sized interpenetrating nets.
         """
         # Get bond except metals.
         I, J, _ = covalent_neighbor_list(self.atoms)
@@ -197,12 +249,17 @@ class MOFDecomposer:
 
     @property
     def building_block_atom_indices(self):
-        """Returns the atom indices of the building blocks.
+        """Group the MOF's atoms into the fragments to be extracted.
+
+        This is the core decomposition result: each set is one building
+        block (a node or a linker), and ``make_building_block_atoms``
+        turns each set into a capped fragment. Computed lazily on first
+        access.
 
         Returns
         -------
-        list[set]:
-            The list of atom indices of the building blocks.
+        list[set]
+            One set of atom indices per detected building block.
         """
         if not self.bb_found:
             self._find_building_block_atom_indices()
@@ -210,17 +267,34 @@ class MOFDecomposer:
 
     @property
     def connecting_sites(self):
+        """Return the atom indices that lie on a connecting bond.
+
+        These are the atoms at the seams between fragments, i.e. the
+        endpoints of the connecting bonds. ``make_building_block_atoms``
+        uses them to decide where to graft the dummy ``X`` connection
+        points onto an extracted fragment.
+
+        Returns
+        -------
+        list[int]
+            Sorted, de-duplicated atom indices appearing in any
+            connecting bond.
+        """
         return np.unique(self.connecting_bonds).tolist()
 
     @property
     def connecting_bonds(self):
-        """Returns the indices of connecting bonds between metal nodes and
-        organic linkes of the MOF.
+        """Return the node-linker bonds that are cut to separate fragments.
+
+        These are the seams of the MOF: severing them splits the structure
+        into the individual building blocks, and their endpoints become the
+        connection points (``X`` atoms) grafted onto each extracted
+        fragment.
 
         Returns
         -------
         list[tuple[int, int]]
-            The list of connecting bonds.
+            Atom-index pairs, one per connecting bond.
         """
 
         if not self.bb_found:
@@ -228,8 +302,10 @@ class MOFDecomposer:
         return self._connecting_bonds
 
     def extract_building_blocks(self):
-        """Extracts building blocks from the MOF. Building blocks are stored in
-        the self.building_blocks property.
+        """Extract every building block and cache them for reuse.
+
+        Materializes a capped fragment for each detected building block and
+        stores the list on the ``building_blocks`` property.
         """
         n_bbs = len(self.building_block_atom_indices)
         self._building_blocks = [
@@ -238,19 +314,48 @@ class MOFDecomposer:
 
     @property
     def building_blocks(self):
-        """Returns the building blocks of the MOF.
+        """Return the extracted building blocks, computing them on demand.
+
+        This is the decomposer's payoff: the capped fragments that PORMAKE
+        could feed back into the forward build pipeline as reusable
+        building blocks.
 
         Returns
         -------
         list[ase.Atoms]
-            The list of building blocks in ase.Atoms format.
+            One capped fragment per building block.
         """
         if not hasattr(self, '_building_blocks'):
             self.extract_building_blocks()
         return self._building_blocks
 
     def make_building_block_atoms(self, i):
-        """Makes building block atoms from the MOF."""
+        """Assemble the ``i``-th building block as a capped fragment.
+
+        Gathers the atoms of the requested fragment, undoes any
+        periodic-boundary cuts so the fragment is contiguous, and then
+        caps each connecting site with a dummy ``X`` atom placed
+        halfway along the severed bond. The result mirrors the
+        connection-point convention of native PORMAKE building blocks,
+        so the extracted fragment can be reused as one.
+
+        Parameters
+        ----------
+        i : int
+            Index into ``building_block_atom_indices`` selecting which
+            fragment to build.
+
+        Returns
+        -------
+        ase.Atoms
+            The contiguous fragment with ``X_type`` connection-point
+            atoms appended at each break point.
+
+        Raises
+        ------
+        AssertionError
+            If ``i`` is out of range for the discovered fragments.
+        """
         assert len(self.building_block_atom_indices) > i
 
         indices = list(self.building_block_atom_indices[i])
@@ -302,8 +407,20 @@ class MOFDecomposer:
         return atoms
 
     def _find_building_block_atom_indices(self):
-        """Finds building blocks and connecting bonds of the MOF. It is an
-        experimental feature and may not be stable."""
+        """Partition the MOF atoms into building-block fragments.
+
+        Core of the decomposition. Builds the covalent-bond graph,
+        removes the metal-coordination edges to expose candidate
+        fragments, then identifies the bridge bonds linking metal
+        clusters to organic linkers as the *connecting bonds* that mark
+        where fragments meet. Self-linking linkers that reconnect to a
+        single parent are merged back in when doing so does not change
+        the fragment's periodic dimension. On completion this caches
+        ``_building_block_atom_indices`` and ``_connecting_bonds`` and
+        sets ``bb_found``.
+
+        It is an experimental feature and may not be stable.
+        """
         # Get full bond information.
         I, J, _ = covalent_neighbor_list(self.atoms)
         bond_list = [[] for _ in range(len(self.atoms))]
@@ -449,6 +566,11 @@ class MOFDecomposer:
                 index_to_bb[j] = i
 
         def is_valid(bridge):
+            """Keep only bridges that still join two distinct fragments.
+
+            After fragment merging some bridges become internal; reads the
+            enclosing ``index_to_bb`` map to drop those.
+            """
             i, j = bridge
             return index_to_bb[i] != index_to_bb[j]
 

--- a/src/pormake/framework.py
+++ b/src/pormake/framework.py
@@ -1,3 +1,16 @@
+"""Represent and serialize the final assembled porous framework.
+
+This module defines :class:`Framework`, the terminal product of the
+PORMAKE pipeline. After :class:`~pormake.builder.Builder` has oriented,
+scaled, and fused all building blocks, it hands the merged periodic
+structure here. The framework couples an :class:`ase.Atoms` object (cell
+plus atomic positions and partial charges) with an explicit bond list
+and per-bond chemical types, and remembers the build provenance in its
+``info`` dictionary. Its main job downstream is to emit a P1 CIF file --
+including periodic-image symmetry codes on bonds -- that other
+crystallography and simulation tools can read.
+"""
+
 import copy
 import os
 import traceback
@@ -13,7 +26,49 @@ from .log import logger
 
 
 class Framework:
+    """Hold a fully assembled periodic framework and write it to CIF.
+
+    Bundles the geometry, bonding, and build metadata produced at the
+    end of an assembly run into one object so the result can be
+    inspected, visualized, and serialized. Bonds are tracked explicitly
+    (rather than re-derived from distances) because the builder knows
+    exactly which atoms were fused when the "X" connection points were
+    removed, which a distance-based guess could get wrong.
+
+    Parameters
+    ----------
+    atoms : ase.Atoms
+        Atoms of the assembled framework, carrying the unit cell,
+        periodic boundary conditions, and per-atom partial charges.
+    bonds : numpy.ndarray
+        Integer array of shape ``(n_bonds, 2)`` listing bonded atom
+        index pairs.
+    bond_types : list of str
+        Chemical bond type label for each entry in ``bonds`` (e.g.
+        ``"S"`` for single).
+    info : dict
+        Build provenance: the (scaled) ``topology``, the list of
+        ``located_bbs``, the chosen ``permutations``, the scaler's
+        ``relax_obj`` value, and the ``max_rmsd``/``mean_rmsd`` of the
+        node placements. Used when writing CIF comments.
+    wrap : bool, optional
+        If ``True`` (default), fold atoms into the unit cell and nudge
+        them off the cell boundary via :meth:`wrap` on construction.
+
+    Attributes
+    ----------
+    atoms : ase.Atoms
+        A copy of the input atoms (possibly wrapped).
+    bonds : numpy.ndarray
+        A copy of the input bond pairs.
+    bond_types : list of str
+        A deep copy of the input bond type labels.
+    info : dict
+        A deep copy of the input build metadata.
+    """
+
     def __init__(self, atoms, bonds, bond_types, info, wrap=True):
+        """Store copies of the geometry, bonds, and metadata."""
         # Save data to attributes.
         self.atoms = atoms.copy()
         self.bonds = bonds.copy()
@@ -24,6 +79,19 @@ class Framework:
             self.wrap()
 
     def wrap(self):
+        """Fold atoms into the cell and off its boundary.
+
+        Exists to keep every atom inside the unit cell and, critically,
+        to avoid fractional coordinates that sit exactly on a cell
+        boundary (0 or 1). Building blocks placed by the builder can land
+        slightly outside the cell or precisely on a face; many CIF
+        parsers and visualizers either reject or double-count atoms whose
+        fractional coordinates equal 0 or 1. This routine repeatedly
+        shifts coordinates back into the ``[0, 1)`` range and then nudges
+        any value within ``1e-3`` of a boundary inward (to ``0.0001`` or
+        ``0.9999``) so the emitted structure is numerically safe
+        downstream. Modifies ``self.atoms`` in place.
+        """
         # Cleanup errors.
         s = self.atoms.get_scaled_positions()
         while (s >= 1.0).any() and (s < 0.0).any():
@@ -44,8 +112,18 @@ class Framework:
         self.atoms.set_scaled_positions(s)
 
     def write_cif(self, filename):
-        """
-        Write framework in cif format.
+        """Write the framework to a CIF file.
+
+        Public, fault-tolerant entry point for serialization. It
+        normalizes the path, appends a ``.cif`` suffix when missing, and
+        delegates the actual formatting to :meth:`_write_cif`. If writing
+        raises, the error is logged and the partially written, invalid
+        file is removed so no corrupt CIF is left behind.
+
+        Parameters
+        ----------
+        filename : str or pathlib.Path
+            Destination path. A ``.cif`` suffix is added if absent.
         """
         path = Path(filename).resolve()
         if not path.parent.exists():
@@ -68,6 +146,23 @@ class Framework:
             os.remove(str(path))
 
     def _write_cif(self, path):
+        """Emit the framework as a P1 CIF at ``path``.
+
+        Writes the full CIF document: provenance comments (topology,
+        building blocks, relaxation objective, RMSD statistics), the P1
+        symmetry block, cell lengths and angles, the atom-site loop with
+        fractional coordinates and partial charges, and a bond loop. For
+        bonds, a neighbor-list search recovers each pair's minimum-image
+        distance and the periodic image of the second atom; bonds that
+        cross a cell boundary are tagged with a ``1_pqr`` symmetry code
+        encoding that image so the periodic connectivity is preserved.
+
+        Parameters
+        ----------
+        path : pathlib.Path
+            Destination file path (already resolved and suffixed by
+            :meth:`write_cif`).
+        """
         stem = path.stem.replace(" ", "_")
 
         with path.open("w") as f:
@@ -187,4 +282,10 @@ class Framework:
                     )
 
     def view(self, *args, **kwargs):
+        """Open the framework atoms in an ASE viewer.
+
+        Thin convenience wrapper around :func:`ase.visualize.view` for
+        quick visual inspection of the assembled structure. Positional
+        and keyword arguments are forwarded unchanged to ASE.
+        """
         ase.visualize.view(self.atoms, *args, **kwargs)

--- a/src/pormake/local_structure.py
+++ b/src/pormake/local_structure.py
@@ -1,3 +1,11 @@
+"""The geometric "currency" matched during placement.
+
+This module defines :class:`LocalStructure`, the normalised set of unit
+direction vectors around a centroid. Both a topology slot (its directions
+to neighbours) and a building block (its directions to connection points)
+are expressed as local structures so the :class:`~pormake.locator.Locator`
+can align one onto the other independently of size or absolute position.
+"""
 import ase
 import ase.visualize
 import numpy as np
@@ -6,13 +14,48 @@ from .utils import write_molecule_cif
 
 
 class LocalStructure:
+    """Describe a slot as a set of unit direction vectors.
+
+    A local structure is the normalized geometric "currency" PORMAKE
+    uses to compare a topology slot with a building block. Given a set
+    of positions (the connection points of a building block, or the
+    neighbour directions around a topology node), it strips away
+    absolute location and bond length, keeping only the unit direction
+    vectors that point from the centroid toward each position. Reducing
+    every slot to this common, scale-free form is what lets the
+    ``Locator`` search for the rotation and permutation that aligns a
+    building block onto a topology slot with minimal RMSD.
+
+    Note that the stored direction vectors are unit-normalized
+    individually, so the centroid of the resulting set is generally
+    *not* the zero vector even though the original geometry was
+    centered first.
+
+    Parameters
+    ----------
+    positions : array_like of shape (n, 3)
+        Cartesian positions defining the slot (e.g. building-block
+        connection points or topology neighbour positions).
+    indices : array_like of int
+        Indices of these positions in the originating structure, kept
+        in the same order as ``positions`` so a match found on the
+        normalized vectors can be mapped back to concrete atoms.
+    normalization_func : callable, optional
+        Alternative normalization to apply instead of the default
+        unit-direction scheme. When ``None`` the default
+        ``normalize_positions`` is used.
+
+    Attributes
+    ----------
+    atoms : ase.Atoms
+        Massless atoms whose positions are the normalized direction
+        vectors.
+    indices : numpy.ndarray of int32
+        The original indices, aligned with ``atoms``.
+    """
+
     def __init__(self, positions, indices, normalization_func=None):
-        """
-        Local structure of the given position.
-        Indices is the indices in the original structure.
-        The order of indices is same as  positions.
-        The center of local structure is zero vector.
-        """
+        """Build a local structure from a set of positions."""
         # Normalize before using.
         if normalization_func is not None:
             positions = normalization_func(positions)
@@ -24,9 +67,38 @@ class LocalStructure:
 
     @property
     def positions(self):
+        """Normalized direction vectors of the slot.
+
+        These are the values the ``Locator`` rotates and permutes when
+        matching this local structure against another.
+
+        Returns
+        -------
+        numpy.ndarray of shape (n, 3)
+            The unit direction vectors stored in ``atoms``.
+        """
         return self.atoms.positions
 
     def normalize_positions(self, positions):
+        """Convert positions to unit directions from their centroid.
+
+        Centers the positions on their centroid and rescales each one
+        to unit length, yielding the orientation-only description the
+        ``Locator`` compares. Because every vector is normalized
+        independently, the centroid of the returned set is generally
+        not zero.
+
+        Parameters
+        ----------
+        positions : array_like of shape (n, 3)
+            Cartesian positions to normalize.
+
+        Returns
+        -------
+        numpy.ndarray of shape (n, 3)
+            Unit direction vectors pointing from the original centroid
+            toward each input position.
+        """
         # Calculate centroid.
         centroid = np.mean(positions, axis=0)
 
@@ -41,6 +113,17 @@ class LocalStructure:
         return positions
 
     def write_cif(self, filename):
+        """Write the local structure to a CIF file.
+
+        Prepends a helium atom at the origin to mark the centroid and
+        draws a bond from it to every direction vector, so the slot's
+        geometry can be inspected visually.
+
+        Parameters
+        ----------
+        filename : str
+            Destination path for the CIF file.
+        """
         atoms = ase.Atoms("He") + self.atoms
         bonds = [(0, i) for i in range(len(atoms))]
         bond_types = ["S" for _ in bonds]
@@ -48,6 +131,17 @@ class LocalStructure:
         write_molecule_cif(filename, atoms, bonds, bond_types)
 
     def view(self, show_origin=True):
+        """Open the local structure in an interactive ASE viewer.
+
+        Convenience helper for visually checking the direction vectors
+        of a slot.
+
+        Parameters
+        ----------
+        show_origin : bool, optional
+            If ``True`` (default), add a helium atom at the origin to
+            mark the centroid for reference.
+        """
         if show_origin:
             atoms = self.atoms + ase.Atom("He")
         else:

--- a/src/pormake/locator.py
+++ b/src/pormake/locator.py
@@ -1,3 +1,22 @@
+"""Align building blocks onto topology slots by rotation and matching.
+
+This module supplies the geometric matching layer of the PORMAKE
+pipeline. A topology slot exposes a ``LocalStructure`` (a set of
+normalized direction vectors pointing toward the slot's neighbors); a
+building block exposes its own ``LocalStructure`` built from the
+directions of its connection-point ("X") atoms. To place a building
+block in a slot we must decide (a) which connection point maps to which
+neighbor direction (a permutation) and (b) the rigid rotation that best
+overlays them. Both are solved here so that the assembled framework has
+chemically sensible, low-strain geometry.
+
+The two module-level functions solve the sub-problems independently --
+optimal assignment via the Hungarian algorithm and optimal rotation via
+the Kabsch algorithm -- and the :class:`Locator` class combines them by
+brute-forcing trial orientations (Euler-angle grid) to escape the local
+optima that a single permutation guess can fall into.
+"""
+
 import itertools
 
 import numpy as np
@@ -7,6 +26,28 @@ from .log import logger
 
 
 def find_best_permutation(p, q):
+    """Find the assignment of ``q`` points onto ``p`` points.
+
+    Solves the linear assignment problem (Hungarian algorithm) on the
+    pairwise distance matrix so that each point in ``q`` is matched to a
+    distinct point in ``p`` with minimal total distance. This decides
+    which connection point of a building block serves which neighbor
+    direction of the target slot before a rotation is fitted.
+
+    Parameters
+    ----------
+    p : numpy.ndarray
+        Target points, shape ``(n, 3)`` (e.g. slot neighbor directions).
+    q : numpy.ndarray
+        Points to be matched against ``p``, shape ``(n, 3)`` (e.g. the
+        building block's connection-point directions).
+
+    Returns
+    -------
+    numpy.ndarray
+        Permutation index array of length ``n`` such that ``q[perm]`` is
+        aligned, element-wise, with ``p``.
+    """
     dist = p[:, np.newaxis] - q[np.newaxis, :]
     dist = np.linalg.norm(dist, axis=-1)
 
@@ -16,19 +57,86 @@ def find_best_permutation(p, q):
 
 
 def find_best_orientation(p, q):
+    """Find the rotation that best overlays ``q`` onto ``p``.
+
+    Wraps :func:`scipy.spatial.transform.Rotation.align_vectors`
+    (Kabsch algorithm) to obtain the rigid rotation minimizing the
+    squared distance between the already-paired point sets. The returned
+    error is converted from the root-"sum"-squared distance that SciPy
+    reports into a per-point root-mean-square deviation (RMSD), the
+    quantity the rest of the pipeline uses to compare fits.
+
+    Parameters
+    ----------
+    p : numpy.ndarray
+        Target points, shape ``(n, 3)``; assumed already permuted to
+        correspond element-wise with ``q``.
+    q : numpy.ndarray
+        Points to be rotated onto ``p``, shape ``(n, 3)``.
+
+    Returns
+    -------
+    U : numpy.ndarray
+        ``(3, 3)`` rotation matrix. It is transposed so that it can be
+        applied as ``positions @ U`` (right-multiplication of row
+        vectors) by the callers.
+    rmsd : float
+        Per-point RMSD of the aligned configuration.
+    """
     # This function gives root "sum" squared distance...
     U, rmsd = scipy.spatial.transform.Rotation.align_vectors(p, q)
     return U.as_matrix().T, np.sqrt(np.square(rmsd) / len(p))
 
 
 class Locator:
-    def locate(self, target, bb, max_n_slices=4):
-        """
-        Locate building block (bb) to target_points
-        using the connection points of the bb.
+    """Orient a building block to a target slot's local structure.
 
-        Return:
-            located building block and RMS.
+    A topology slot only fixes the *directions* toward its neighbors;
+    the building block must be rotated so that its connection points
+    point along those directions. Because the correct point-to-direction
+    pairing is not known in advance, this class scans a grid of trial
+    orientations over Euler angles, solving the assignment problem at
+    each trial and keeping the rotation/permutation pair with the lowest
+    RMSD. The Euler scan makes the result robust against the local
+    minima that arise when an arbitrary initial permutation is fitted
+    directly. The matched building block, its winning permutation, and
+    the RMSD are returned for use by :class:`~pormake.builder.Builder`
+    and :class:`~pormake.scaler.Scaler`.
+    """
+
+    def locate(self, target, bb, max_n_slices=4):
+        """Orient ``bb`` onto ``target`` and find the best permutation.
+
+        Scans a coarse Euler-angle grid (whose density adapts to the
+        number of connection points and to ``max_n_slices``); at each
+        trial orientation it solves for the best connection-point
+        permutation, fits the optimal rotation for that permutation, and
+        retains the lowest-RMSD result. Only orientation is applied
+        here -- translation onto the final cell position happens later
+        in the build, after the topology is scaled.
+
+        Parameters
+        ----------
+        target : LocalStructure
+            The slot's local structure (neighbor direction vectors) the
+            building block should be aligned to.
+        bb : BuildingBlock
+            The building block to orient. It is copied before rotation,
+            so the input is left unchanged.
+        max_n_slices : int, optional
+            Controls the Euler-angle grid resolution. The effective
+            number of slices per angle is reduced for slots with few
+            connection points (2, 3, or 4) and equals ``max_n_slices``
+            otherwise. Larger values trade speed for accuracy.
+
+        Returns
+        -------
+        bb : BuildingBlock
+            A rotated copy of the input building block.
+        min_perm : numpy.ndarray
+            The connection-point permutation that achieved the best fit.
+        rmsd_val : float
+            Per-point RMSD of the returned orientation.
         """
         local0 = target
         local1 = bb.local_structure()
@@ -101,8 +209,32 @@ class Locator:
         return bb, min_perm, rmsd_val
 
     def locate_with_permutation(self, target, bb, permutation):
-        """
-        Locate bb to target with pre-obtained permutation of bb.
+        """Orient ``bb`` onto ``target`` using a known permutation.
+
+        Skips the expensive Euler-angle search of :meth:`locate` by
+        reusing a connection-point permutation that was determined
+        earlier (e.g. the one returned by :meth:`locate`, or the trivial
+        edge permutation). Only the optimal rotation for that fixed
+        permutation is fitted. This is used during the relocation step
+        after the topology cell has been scaled, where the pairing is
+        already settled and only the new geometry needs re-fitting.
+
+        Parameters
+        ----------
+        target : LocalStructure
+            The slot's local structure to align the building block to.
+        bb : BuildingBlock
+            The building block to orient; copied before rotation.
+        permutation : array_like
+            Connection-point permutation mapping ``bb`` points onto the
+            target directions.
+
+        Returns
+        -------
+        bb : BuildingBlock
+            A rotated copy of the input building block.
+        rmsd_val : float
+            Per-point RMSD of the returned orientation.
         """
         local0 = target
         local1 = bb.local_structure()
@@ -136,5 +268,30 @@ class Locator:
         return bb, rmsd_val
 
     def calculate_rmsd(self, target, bb, max_n_slices=6):
+        """Return only the best-fit RMSD of ``bb`` against ``target``.
+
+        Convenience wrapper around :meth:`locate` that discards the
+        rotated building block and permutation, keeping just the RMSD.
+        The builder uses it to establish the minimum achievable RMSD for
+        a given (node type, building block) pair so it can detect when a
+        placement is sub-optimal and warrants a higher-accuracy or
+        chiral retry.
+
+        Parameters
+        ----------
+        target : LocalStructure
+            The slot's local structure to evaluate the fit against.
+        bb : BuildingBlock
+            The building block being tested.
+        max_n_slices : int, optional
+            Euler-angle grid resolution passed through to
+            :meth:`locate`; defaults to a finer grid than ``locate`` so
+            the reference minimum is reliable.
+
+        Returns
+        -------
+        float
+            Per-point RMSD of the best orientation found.
+        """
         _, _, rmsd_val = self.locate(target, bb, max_n_slices)
         return rmsd_val

--- a/src/pormake/log.py
+++ b/src/pormake/log.py
@@ -1,3 +1,20 @@
+"""Configure PORMAKE's single shared logger.
+
+PORMAKE routes all of its diagnostics through one module-level
+``logger`` named ``"unique_logger"``. Centralizing on a single logger
+keeps the assembly pipeline's output consistent and lets callers toggle
+verbosity from one place. The logger sets ``propagate = False`` so its
+records do not bubble up to the root logger and collide with logging
+configured by other libraries.
+
+Two handlers are attached. A :class:`logging.FileHandler` writes every
+level (``DEBUG`` and up) to ``runtime.log`` for a detailed trace, while
+a :class:`logging.StreamHandler` prints a simplified ``>>>``-prefixed
+message to the console at ``INFO`` and above. The helper functions in
+this module raise or lower each handler's threshold so users can quiet
+or restore console and file output independently at runtime.
+"""
+
 import logging
 
 # Make a logger. Pormake uses a single logger.
@@ -34,20 +51,41 @@ logger.addHandler(console_log_handler)
 
 
 def disable_print():
+    """Silence console messages below the ``WARNING`` level.
+
+    Raises the console handler's threshold to ``WARNING`` so routine
+    ``INFO``/``DEBUG`` progress messages no longer print to the screen.
+    """
     console_log_handler.setLevel(logging.WARNING)
     logger.warning("Console logs (under WARNING level) are disabled.")
 
 
 def enable_print():
+    """Restore console messages at the ``INFO`` level and above.
+
+    Lowers the console handler's threshold back to ``INFO``, undoing a
+    previous :func:`disable_print` call.
+    """
     console_log_handler.setLevel(logging.INFO)
     logger.warning("Console logs (under WARNING level) are enabled.")
 
 
 def disable_file_print():
+    """Silence file-log messages below the ``WARNING`` level.
+
+    Raises the file handler's threshold to ``WARNING`` so the
+    ``runtime.log`` file records only warnings and errors.
+    """
     file_log_handler.setLevel(logging.WARNING)
     logging.warning("File logs (under WARNING level) are disabled.")
 
 
 def enable_file_print():
+    """Restore full ``DEBUG``-level logging to the file.
+
+    Lowers the file handler's threshold back to ``DEBUG`` so every level
+    is written to ``runtime.log`` again, undoing
+    :func:`disable_file_print`.
+    """
     file_log_handler.setLevel(logging.DEBUG)
     logging.warning("File logs (all levels) are enabled.")

--- a/src/pormake/neighbor_list.py
+++ b/src/pormake/neighbor_list.py
@@ -1,3 +1,13 @@
+"""Connectivity between topology nodes and edge centers.
+
+This module turns the bare atomic positions of a parsed net into an
+explicit adjacency structure. :class:`Neighbor` is a single
+(index, distance-vector) record and :class:`NeighborList` builds the full
+node-edge connectivity used everywhere downstream: the
+:class:`~pormake.topology.Topology` derives local structures and edge
+types from it, and the :class:`~pormake.scaler.Scaler` rewrites it with
+rescaled edge geometry after cell optimization.
+"""
 import ase
 import ase.neighborlist
 import numpy as np
@@ -6,22 +16,87 @@ from .log import logger
 
 
 class Neighbor:
+    """Hold a single topology connectivity record.
+
+    A ``Neighbor`` is one entry in a slot's neighbor list: it pairs the
+    integer index of an adjacent slot (a node or an edge-center in the
+    underlying ``ase.Atoms``) with the minimum-image displacement vector
+    pointing from the owning slot toward that neighbor. Storing the
+    displacement (rather than just the index) keeps periodic-boundary
+    information intact, which is what lets ``Topology`` recover each
+    slot's local geometry and lets the ``Locator`` align building blocks.
+
+    Attributes
+    ----------
+    index : int
+        Index, in the topology's ``ase.Atoms`` object, of the neighboring
+        node or edge-center slot.
+    distance_vector : numpy.ndarray
+        Minimum-image Cartesian displacement from the owning slot to the
+        neighbor; its direction defines part of the slot's local
+        structure and its norm is the through-space distance.
+    """
+
     def __init__(self, index, distance_vector):
+        """Store the neighbor's slot index and displacement vector."""
         self.index = index
         self.distance_vector = distance_vector
 
     def __repr__(self):
+        """Return a one-line ``index``/``distance vector`` summary."""
         return "index: {}, distance vector: {}".format(
             self.index, self.distance_vector
         )
 
 
 class NeighborList:
-    """
-    Make the connectivity between nodes and edge centers for the topologies.
+    """Build node-to-edge-center connectivity for a topology.
+
+    A topology net is stored as an ``ase.Atoms`` object in which carbon
+    ("C") atoms mark node (vertex) slots and oxygen ("O") atoms mark
+    edge-center slots. ``NeighborList`` scans that geometry once and
+    records, for every slot, which slots it is bonded to and the
+    minimum-image displacement to each. The result is a list indexed by
+    slot: ``neighbor_list[i]`` yields the ``Neighbor`` records of slot
+    ``i``. Every edge-center should end up with exactly two node
+    neighbors, and each node with as many edge-center neighbors as its
+    coordination number; ``Topology`` relies on this object to validate
+    those counts and to build per-slot ``LocalStructure`` objects.
+
+    Two construction strategies are offered because ``.cgd`` files vary
+    in numerical precision: ``"distance"`` bonds C-O pairs within a fixed
+    cutoff, while ``"nearest"`` keeps each edge-center's two closest
+    nodes and prunes asymmetric bonds. ``Topology`` tries the cheaper
+    distance method first and falls back to the nearest-two method when
+    validation fails.
+
+    Parameters
+    ----------
+    atoms : ase.Atoms
+        Topology geometry whose "C" atoms are node slots and "O" atoms
+        are edge-center slots.
+    method : {"distance", "nearest"}
+        Connectivity strategy. ``"distance"`` uses a fixed C-O cutoff;
+        ``"nearest"`` keeps the two nearest nodes per edge-center and
+        removes non-reciprocal bonds.
+
+    Attributes
+    ----------
+    max_index : int
+        Largest slot index seen while building, i.e. one less than the
+        number of slots that own a neighbor list.
+    _neighbor_list : list of list of Neighbor
+        Per-slot adjacency: entry ``i`` holds the ``Neighbor`` records
+        for slot ``i``.
+
+    Raises
+    ------
+    Exception
+        If ``method`` is neither ``"distance"`` nor ``"nearest"``.
     """
 
     def __init__(self, atoms, method):
+        """Build connectivity from ``atoms`` using the chosen ``method``."""
         # C for nodes and O for edges.
         if method == "distance":
             self.distance_based_build(atoms)
@@ -32,6 +107,20 @@ class NeighborList:
             raise Exception("Invalid arguments.")  # Hmm...
 
     def distance_based_build(self, atoms):
+        """Build connectivity by bonding C-O pairs within a fixed cutoff.
+
+        Uses ASE's neighbor search with a small C-O cutoff (and zero C-C
+        and O-O cutoffs) so that only node-to-edge-center bonds are kept.
+        This is the fast, precision-sensitive default; ``Topology`` calls
+        it first and only falls back to ``nearest_two_based_build`` if the
+        resulting coordination numbers do not validate.
+
+        Parameters
+        ----------
+        atoms : ase.Atoms
+            Topology geometry whose "C" atoms are nodes and "O" atoms are
+            edge-centers.
+        """
         eps = 1e-3
         cutoffs = {
             ("C", "C"): 0.0,
@@ -48,6 +137,22 @@ class NeighborList:
             self._neighbor_list[i].append(Neighbor(j, d))
 
     def nearest_two_based_build(self, atoms):
+        """Build connectivity by keeping each edge-center's two nearest nodes.
+
+        This fallback strategy first gathers C-O bonds within a looser
+        cutoff, then for every edge-center ("O") slot retains only the two
+        nodes closest to it (an edge always joins exactly two nodes), and
+        finally drops any node-side neighbor that does not reciprocate.
+        It is more tolerant of imprecise ``.cgd`` coordinates than the
+        distance method, so ``Topology`` uses it when distance-based
+        parsing fails validation.
+
+        Parameters
+        ----------
+        atoms : ase.Atoms
+            Topology geometry whose "C" atoms are nodes and "O" atoms are
+            edge-centers.
+        """
         # C for nodes and O for edges.
         cutoffs = {
             ("C", "C"): 0.0,
@@ -83,12 +188,46 @@ class NeighborList:
             self._neighbor_list[i] = neighbor
 
     def __getitem__(self, i):
+        """Return the list of ``Neighbor`` records for slot ``i``.
+
+        Parameters
+        ----------
+        i : int
+            Slot index (a node or edge-center) in the topology.
+
+        Returns
+        -------
+        list of Neighbor
+            Connectivity records of slot ``i``.
+        """
         return self._neighbor_list[i]
 
     def __iter__(self):
+        """Iterate over slots, yielding each slot's ``Neighbor`` list.
+
+        Returns
+        -------
+        iterator
+            Iterator over the per-slot lists of ``Neighbor`` records, in
+            slot-index order.
+        """
         return iter(self._neighbor_list)
 
     def set_data(self, data):
+        """Replace the connectivity with externally supplied records.
+
+        Rebuilds the internal per-slot adjacency from raw
+        ``(index, distance_vector)`` pairs. ``Scaler`` calls this after
+        rescaling the topology cell so the neighbor list reflects the new,
+        building-block-sized geometry while preserving which slots connect.
+
+        Parameters
+        ----------
+        data : iterable of iterable of (int, numpy.ndarray)
+            Per-slot connectivity. Each inner iterable holds
+            ``(index, distance_vector)`` pairs that become ``Neighbor``
+            records for that slot.
+        """
         new_list = []
         for neighbor in data:
             new_list.append([])
@@ -98,6 +237,14 @@ class NeighborList:
         self._neighbor_list = new_list
 
     def __repr__(self):
+        """Return a multi-line per-slot listing of neighbor counts and records.
+
+        Returns
+        -------
+        str
+            One block per slot showing ``slot: count`` followed by each
+            ``Neighbor`` record, for quick inspection of the connectivity.
+        """
         output = ""
         for i, neighbor in enumerate(self):
             line = "{}: {}\n".format(i, len(neighbor))

--- a/src/pormake/scaler.py
+++ b/src/pormake/scaler.py
@@ -1,3 +1,13 @@
+"""Cell rescaling that fits a net to its building blocks.
+
+This module defines :class:`Scaler`, the geometry-optimization stage of
+the build pipeline. An abstract net has arbitrary edge lengths, so before
+real molecular fragments can be placed the unit cell and slot positions
+must be resized to match the actual sizes of the chosen building blocks.
+:class:`Scaler` formulates that as a least-squares problem over node-edge
+angles and lengths and solves it with JAX-computed gradients driving a
+SciPy L-BFGS-B optimizer.
+"""
 from collections import defaultdict
 from itertools import product
 
@@ -12,24 +22,78 @@ from .utils import bound_values
 
 
 class Scaler:
-    """
-    Scale topology using given nodes and edges building blocks information.
+    """Resize an abstract net so chosen building blocks fit without strain.
+
+    A :class:`~pormake.topology.Topology` read from a ``.cgd`` file is a
+    purely abstract net: its unit cell and node spacing are arbitrary
+    and do not reflect the real sizes of the molecular fragments that
+    will be placed on it. ``Scaler`` solves that mismatch. Given the
+    building blocks assigned to each node and edge, it rescales the
+    topology's unit cell and node positions so that node-to-node
+    distances and inter-edge angles agree with the actual building-block
+    geometry. Producing a net whose dimensions match the fragments is
+    what makes the final framework chemically reasonable rather than
+    distorted.
+
+    Internally, :meth:`scale` derives a set of target dot products
+    between connection-point vectors (encoding both bond lengths and
+    angles) from the building blocks, then runs an L-BFGS-B geometry
+    optimization (with JAX-computed gradients) over the scaled atomic
+    positions and the 3x3 cell matrix to match those targets. It
+    finishes by rebuilding the topology's neighbor list with the
+    rescaled edge geometry.
+
+    Parameters
+    ----------
+    length_weight : float, optional
+        Relative weight given to length (self dot-product) terms versus
+        angle (cross dot-product) terms in the optimization objective.
+        Values above 1 emphasize matching edge lengths over angles.
+
+    Attributes
+    ----------
+    length_weight : float
+        The stored length-versus-angle weighting used by :meth:`scale`.
     """
 
     def __init__(self, length_weight=1.0):
-        """
-        Inputs:
-            topology: topology
-            bbs: list of BuildingBlocks. The order of bb have to be same as
-                topology.
-            permutations
-        """
+        """Store the length-versus-angle weighting for the objective."""
         self.length_weight = length_weight
 
     def scale(self, topology, bbs, perms, return_result=False):
-        """
-        Scale topology using building block information.
-        Both lengths and angles are optimized during the process.
+        """Rescale a topology to match its assigned building blocks.
+
+        Forms length/angle targets from the building blocks placed on
+        each node and edge, then optimizes the scaled atomic positions
+        and the unit-cell matrix so the net's geometry matches those
+        targets. The returned topology is a rescaled copy whose neighbor
+        list has been rebuilt with the new edge centers, ready for the
+        builder to assemble the final framework. Both edge lengths and
+        node-edge-node angles are optimized simultaneously.
+
+        Parameters
+        ----------
+        topology : pormake.topology.Topology
+            The abstract net to rescale. Not modified in place.
+        bbs : list of pormake.building_block.BuildingBlock or None
+            Building blocks indexed by slot. Node slots must hold a
+            building block; edge slots may be ``None`` when no edge
+            building block is present.
+        perms : list
+            Per-node connection-point permutations, indexed by slot,
+            describing how each building block's connection points map
+            onto the node's edges.
+        return_result : bool, optional
+            If ``True``, also return the raw SciPy optimization result.
+
+        Returns
+        -------
+        scaled_topology : pormake.topology.Topology
+            A rescaled copy of ``topology`` with updated cell, positions,
+            and neighbor list.
+        result : scipy.optimize.OptimizeResult
+            The optimizer result, returned only when ``return_result``
+            is ``True``.
         """
         logger.debug("Scaler.scale starts.")
 
@@ -196,12 +260,24 @@ class Scaler:
 
         # Helper functions for calculation of objective function.
         def calc_dots(s, c):
-            """
-            Inputs:
-                s: scaled positions.
-                c: cell matrix (row is a lattice vector).
-            External variables:
-                topology, pairs, image, ij, ik, ij_image, ik_image.
+            """Compute dot products of edge-vector pairs at every node.
+
+            Closes over the enclosing-scope triple-index arrays ``ij``,
+            ``ik`` and their periodic images ``ij_image``, ``ik_image``
+            to build the Cartesian edge vectors and their pairwise dots,
+            the quantities compared against ``target_dots``.
+
+            Parameters
+            ----------
+            s : jax.numpy.ndarray
+                Scaled (fractional) positions, shape ``(n, 3)``.
+            c : jax.numpy.ndarray
+                Cell matrix, one lattice vector per row.
+
+            Returns
+            -------
+            jax.numpy.ndarray
+                Dot product for each ``(ij, ik)`` edge-vector pair.
             """
             # diff becames n x n x 3 tensor with element of
             # diff[i, j, :] = si - sj.
@@ -215,11 +291,25 @@ class Scaler:
             return dots
 
         def objective(s, c):
+            """Return the weighted mean-squared dot-product error.
+
+            Compares the current geometry's dot products from
+            :func:`calc_dots` against the enclosing-scope ``target_dots``
+            and reduces them to a single scalar using ``weights``; this
+            is the quantity minimized by the optimizer.
+            """
             dots = calc_dots(s, c)
             return jnp.mean(jnp.square(dots - target_dots) * weights)
 
         # Functions for scipy interface.
         def fun(x):
+            """Evaluate the objective from a flat parameter vector.
+
+            Unpacks the flat vector ``x`` (positions followed by the 9
+            cell entries) into ``s`` and ``c`` and forwards them to
+            :func:`objective`. Uses the enclosing-scope ``topology`` for
+            the slot count.
+            """
             n = topology.n_slots
 
             s = jnp.reshape(x[:-9], (n, 3))
@@ -232,9 +322,19 @@ class Scaler:
         jac = jax.jit(jax.grad(fun))
 
         def fun_numpy(x):
+            """Evaluate :func:`fun` and cast the result to NumPy float64.
+
+            Adapts the JAX objective to the plain-float interface that
+            :func:`scipy.optimize.minimize` expects.
+            """
             return np.array(fun(x), dtype=np.float64)
 
         def jac_numpy(x):
+            """Evaluate the JAX gradient ``jac`` as a NumPy float64 array.
+
+            Adapts the JIT-compiled gradient of :func:`fun` to the
+            array interface SciPy's L-BFGS-B optimizer requires.
+            """
             return np.array(jac(x), dtype=np.float64)
 
         # Prepare geometry optimization.

--- a/src/pormake/topology.py
+++ b/src/pormake/topology.py
@@ -1,3 +1,13 @@
+"""The abstract net that organizes a framework.
+
+This module defines :class:`Topology`, the blueprint that says how many
+building-block slots exist and how they connect, without any chemistry
+attached yet. Read from a ``.cgd`` file, it classifies slots into node and
+edge types, exposes each slot's local structure for the
+:class:`~pormake.locator.Locator`, and is rescaled by the
+:class:`~pormake.scaler.Scaler` before the :class:`~pormake.builder.Builder`
+populates it with real building blocks.
+"""
 import copy
 import functools
 import os
@@ -16,14 +26,80 @@ from .utils import read_cgd
 
 
 class Topology:
+    """Represent an abstract periodic net that scaffolds a framework.
+
+    A ``Topology`` is the blueprint stage of the PORMAKE pipeline: it is
+    read from a ``.cgd`` file describing a reticular net and holds the
+    positions, unit cell, and connectivity of that net. Geometry lives in
+    an ``ase.Atoms`` object where carbon ("C") atoms are node (vertex)
+    slots and oxygen ("O") atoms are edge-center slots; integer tags on
+    each atom encode its type (tag ``>= 0`` for a node type, tag ``< 0``
+    for an edge). On construction the net's connectivity is built into a
+    ``NeighborList`` and validated (coordination numbers and edge
+    zero-sum), then per-slot and per-type properties are cached.
+
+    Downstream stages consume this object: the ``Scaler`` rescales its
+    cell to fit chosen building blocks, the ``Locator`` aligns each
+    ``BuildingBlock`` to the ``LocalStructure`` of the slot it occupies,
+    and the ``Builder`` assembles the result into a ``Framework``. A
+    "slot" is any node or edge position a building block can fill; an
+    "edge type" is the sorted pair of node-types an edge connects.
+
+    Parameters
+    ----------
+    cgd_file : str or pathlib.Path
+        Path to the ``.cgd`` file describing the net to parse.
+    local_structure_func : callable, optional
+        Normalization function forwarded to each ``LocalStructure``
+        produced for a slot; controls how raw neighbor directions are
+        normalized before the ``Locator`` matches a building block. If
+        ``None``, the ``LocalStructure`` default is used.
+
+    Attributes
+    ----------
+    atoms : ase.Atoms
+        Net geometry: "C" atoms are node slots, "O" atoms are
+        edge-centers, integer tags encode node/edge type, and
+        ``atoms.info`` carries ``"name"``, ``"spacegroup"`` and ``"cn"``.
+    name : str
+        Net identifier read from the ``.cgd`` file.
+    spacegroup : str
+        Space-group label of the net.
+    neighbor_list : NeighborList
+        Node-to-edge-center connectivity used for validation and for
+        building local structures.
+    local_structure_func : callable or None
+        Normalization function applied when constructing each slot's
+        ``LocalStructure``.
+    cn : numpy.ndarray
+        Per-slot coordination numbers (from ``atoms.info["cn"]``).
+    unique_cn : numpy.ndarray
+        One coordination number per unique node type, aligned with
+        ``unique_node_types``.
+    """
+
     def __init__(self, cgd_file, local_structure_func=None):
+        """Parse ``cgd_file`` and build/validate the net's properties."""
         self.atoms = read_cgd(filename=cgd_file)
         self.update_properties()
         self.local_structure_func = local_structure_func
 
     def update_properties(self):
-        """
-        Calculate topology properties from information in self.atoms.
+        """Parse, validate, and cache all net properties from ``self.atoms``.
+
+        Reads the net name and space group, builds a ``NeighborList`` with
+        the fast distance method and, if validation fails, retries with
+        the more tolerant nearest-two method. Once a valid connectivity is
+        found, ``calculate_properties`` is called to derive node/edge
+        indices, types, and counts. This is the single entry point that
+        refreshes everything after the geometry changes (e.g. after
+        ``__mul__`` replaces ``self.atoms``).
+
+        Raises
+        ------
+        Exception
+            If neither connectivity method yields a valid net (i.e. the
+            ``.cgd`` file is malformed).
         """
 
         # Save additional information.
@@ -50,12 +126,39 @@ class Topology:
         self.calculate_properties()
 
     def check_coordination_numbers(self):
+        """Verify each slot's neighbor count matches its expected CN.
+
+        Compares the coordination numbers declared in the ``.cgd`` file
+        (``atoms.info["cn"]``) against the number of neighbors the
+        ``NeighborList`` actually found for each slot. A mismatch means
+        the connectivity was parsed incorrectly.
+
+        Returns
+        -------
+        bool
+            ``True`` if every slot's neighbor count equals its declared
+            coordination number, ``False`` otherwise.
+        """
         for cn, ns in zip(self.atoms.info["cn"], self.neighbor_list):
             if cn != len(ns):
                 return False
         return True
 
     def check_edge_zerosum(self):
+        """Verify each edge-center sits midway between its two nodes.
+
+        A correctly parsed edge-center has exactly two node neighbors
+        whose displacement vectors are equal and opposite, so they sum to
+        zero (within a small tolerance). A non-zero sum signals that the
+        edge-center is not centered on its bond and the connectivity is
+        wrong.
+
+        Returns
+        -------
+        bool
+            ``True`` if every edge-center's two neighbor displacements
+            cancel to within ``1e-3``, ``False`` otherwise.
+        """
         eps = 1e-3
         edge_indices = np.argwhere(self.atoms.get_tags() == -1).reshape(-1)
         for e in edge_indices:
@@ -69,6 +172,19 @@ class Topology:
         return True
 
     def check_validity(self):
+        """Check that the parsed connectivity is self-consistent.
+
+        Combines the two structural checks: coordination numbers must
+        match the declared values and every edge-center must be balanced
+        between its two nodes. ``update_properties`` uses the result to
+        decide whether the current connectivity method succeeded.
+
+        Returns
+        -------
+        bool
+            ``True`` only if both ``check_coordination_numbers`` and
+            ``check_edge_zerosum`` pass.
+        """
         if not self.check_coordination_numbers():
             return False
         if not self.check_edge_zerosum():
@@ -76,9 +192,28 @@ class Topology:
         return True
 
     def copy(self):
+        """Return a deep, independent copy of this topology.
+
+        Returns
+        -------
+        Topology
+            A fully detached duplicate (geometry, connectivity, and cached
+            properties) safe to mutate without affecting the original;
+            used, for example, by ``__mul__`` to build a supercell.
+        """
         return copy.deepcopy(self)
 
     def calculate_properties(self):
+        """Derive cached node/edge indices, types, and counts.
+
+        From the validated ``ase.Atoms`` tags and ``NeighborList`` this
+        precomputes the data the rest of the pipeline queries repeatedly:
+        which slots are nodes vs. edges, each slot's node type, each
+        edge's (sorted) pair of adjacent node-types, the number of unique
+        node and edge types, and the coordination number of each unique
+        node type. Called by ``update_properties`` after a valid
+        connectivity is established.
+        """
         # Build indices of nodes and edges.
         self._node_indices = np.argwhere(self.atoms.get_tags() >= 0).reshape(-1)
         self._edge_indices = np.argwhere(self.atoms.get_tags() < 0).reshape(-1)
@@ -123,6 +258,28 @@ class Topology:
         self.unique_cn = np.array(self.unique_cn)
 
     def local_structure(self, i):
+        """Return the normalized neighbor directions around slot ``i``.
+
+        Gathers the displacement vectors from slot ``i`` to each of its
+        neighbors and packages them as a ``LocalStructure`` -- the
+        normalized set of directions that defines the slot's connection
+        geometry. This is the geometric "currency" the ``Locator``
+        matches against a building block's own ``LocalStructure`` (via
+        RMSD minimization) to orient and place that block into slot ``i``.
+
+        Parameters
+        ----------
+        i : int
+            Slot index (node or edge-center) whose local geometry to
+            extract.
+
+        Returns
+        -------
+        LocalStructure
+            Neighbor directions of slot ``i``, normalized with
+            ``self.local_structure_func``, tagged with the neighbor slot
+            indices.
+        """
         indices = []
         positions = []
         for n in self.neighbor_list[i]:
@@ -134,13 +291,54 @@ class Topology:
         )
 
     def get_node_type(self, i):
+        """Return the node type of slot ``i``.
+
+        Parameters
+        ----------
+        i : int
+            Slot index.
+
+        Returns
+        -------
+        int
+            The slot's integer tag/node type (``>= 0`` for nodes; for an
+            edge-center this is its negative edge tag).
+        """
         return self._node_types[i]
 
     def get_edge_type(self, i):
+        """Return the (sorted) node-type pair an edge slot connects.
+
+        Parameters
+        ----------
+        i : int
+            Slot index. Meaningful for edge slots; node slots carry the
+            placeholder ``(-1, -1)``.
+
+        Returns
+        -------
+        numpy.ndarray
+            The two adjacent node types as a sorted ``(t0, t1)`` pair,
+            which is how edge types are identified and grouped.
+        """
         return self._edge_types[i]
 
     @property
     def unique_local_structures(self):
+        """Return one representative ``LocalStructure`` per node type.
+
+        Picks the first slot of each unique node type and returns its
+        local structure, giving the distinct connection geometries the
+        net contains. The ``Locator`` only needs to solve the alignment
+        problem once per node type, so this list (aligned with
+        ``unique_node_types``) is the natural unit of work.
+
+        Returns
+        -------
+        list of LocalStructure
+            One local structure per unique node type, in ascending
+            node-type order.
+        """
         types = np.unique(self.node_types[self.node_indices])
         local_structures = []
         for t in types:
@@ -150,61 +348,201 @@ class Topology:
 
     @property
     def unique_node_types(self):
+        """Return the distinct node types present in the net.
+
+        Returns
+        -------
+        numpy.ndarray
+            Sorted unique node-type tags; the set of vertex kinds that
+            each need a building block assigned.
+        """
         return np.unique(self.node_types[self.node_indices])
 
     @property
     def unique_edge_types(self):
+        """Return the distinct edge types present in the net.
+
+        Returns
+        -------
+        numpy.ndarray
+            Unique ``(t0, t1)`` node-type pairs over all edge slots; the
+            set of edge kinds that may each take a (linker) building
+            block.
+        """
         return np.unique(self.edge_types[self.edge_indices], axis=0)
 
     @property
     def node_types(self):
+        """Return the per-slot node-type array.
+
+        Returns
+        -------
+        numpy.ndarray
+            The integer tag of every slot (length ``n_slots``); for edge
+            slots this is the negative edge tag. Index with
+            ``node_indices`` to restrict to true nodes.
+        """
         return self._node_types
 
     @property
     def edge_types(self):
+        """Return the per-slot edge-type array.
+
+        Returns
+        -------
+        numpy.ndarray
+            For each slot, the sorted ``(t0, t1)`` pair of adjacent node
+            types; node slots hold the placeholder ``(-1, -1)``. Index
+            with ``edge_indices`` to restrict to true edges.
+        """
         return self._edge_types
 
     @property
     def n_all_points(self):
+        """Return the total number of slots in the net.
+
+        Returns
+        -------
+        int
+            Count of all atoms in ``self.atoms``, i.e. nodes plus
+            edge-centers.
+        """
         return len(self.atoms)
 
     @property
     def n_slots(self):
+        """Return the number of fillable slots (alias of ``n_all_points``).
+
+        Returns
+        -------
+        int
+            Total node and edge-center slots a building block can occupy.
+        """
         return self.n_all_points
 
     @property
     def node_indices(self):
+        """Return the slot indices that are nodes (vertices).
+
+        Returns
+        -------
+        numpy.ndarray
+            Indices into ``self.atoms`` of slots with tag ``>= 0``.
+        """
         return self._node_indices
 
     @property
     def edge_indices(self):
+        """Return the slot indices that are edge-centers.
+
+        Returns
+        -------
+        numpy.ndarray
+            Indices into ``self.atoms`` of slots with tag ``< 0``.
+        """
         return self._edge_indices
 
     @property
     def n_nodes(self):
+        """Return the number of node (vertex) slots.
+
+        Returns
+        -------
+        int
+            Count of node slots in the net.
+        """
         return len(self.node_indices)
 
     @property
     def n_edges(self):
+        """Return the number of edge-center slots.
+
+        Returns
+        -------
+        int
+            Count of edge slots in the net.
+        """
         return len(self.edge_indices)
 
     @property
     def n_node_types(self):
+        """Return the number of distinct node types.
+
+        Returns
+        -------
+        int
+            How many unique vertex kinds the net contains; the number of
+            independent building-block choices for nodes.
+        """
         return self._n_node_types
 
     @property
     def n_edge_types(self):
+        """Return the number of distinct edge types.
+
+        Returns
+        -------
+        int
+            How many unique edge kinds (node-type pairs) the net
+            contains.
+        """
         return self._n_edge_types
 
     def get_neighbor_indices(self, i):
+        """Return the slot indices adjacent to slot ``i``.
+
+        Parameters
+        ----------
+        i : int
+            Slot index whose neighbors to list.
+
+        Returns
+        -------
+        list of int
+            Indices of the slots bonded to slot ``i``, drawn from the
+            ``NeighborList``.
+        """
         return [n.index for n in self.neighbor_list[i]]
 
     def get_edge_length(self, i):
+        """Return the through-space length of edge slot ``i``.
+
+        Computes the distance between the edge-center's two node
+        neighbors from their displacement vectors. ``Scaler`` uses such
+        lengths when sizing the cell to fit the chosen building blocks.
+
+        Parameters
+        ----------
+        i : int
+            Edge slot index (an edge-center with exactly two neighbors).
+
+        Returns
+        -------
+        float
+            Euclidean distance between the edge's two adjacent nodes.
+        """
         n1, n2 = self.neighbor_list[i]
         diff = n1.distance_vector - n2.distance_vector
         return np.linalg.norm(diff)
 
     def view(self, show_edge_centers=True, *args, **kwargs):
+        """Open an interactive ASE viewer of the net.
+
+        Renders the abstract net for visual inspection. The unit cell is
+        expanded so vertices and bonds are easy to see; when edge-centers
+        are shown their "O" atoms are relabeled "F" purely so the viewer
+        draws the node-edge bonds clearly. The geometry of ``self`` is not
+        modified (a copy is displayed).
+
+        Parameters
+        ----------
+        show_edge_centers : bool, optional
+            If ``True`` (default), display edge-center slots (relabeled
+            for bond visibility); if ``False``, remove them and show only
+            nodes.
+        *args, **kwargs
+            Forwarded to ``ase.visualize.view``.
+        """
         atoms = self.atoms.copy()
 
         if show_edge_centers:
@@ -225,6 +563,15 @@ class Topology:
         ase.visualize.view(atoms, *args, **kwargs)
 
     def __repr__(self):
+        """Return a one-line summary naming the net, its CNs, and edge types.
+
+        Returns
+        -------
+        str
+            Text of the form ``Topology <name>, (cn, ...)-cn, num edge
+            types: <n>`` summarizing the coordination numbers of the
+            unique node types and the number of edge types.
+        """
         msg = "Topology {}, (".format(self.name)
         for cn in self.unique_cn:
             msg += f"{cn},"
@@ -233,8 +580,25 @@ class Topology:
         return msg
 
     def write_cif(self, filename, with_edge_atoms=False, *args, **kwargs):
-        """
-        Write topology in cif format.
+        """Write the abstract net to a CIF file for visualization.
+
+        Serializes the net (in P1 symmetry) so it can be inspected in
+        crystallography viewers. Each slot type is mapped to a distinct
+        chemical symbol and node-edge connectivity is emitted as CIF
+        bonds. The ``.cif`` suffix is added if missing; if writing fails,
+        the partially written file is removed and the error is logged.
+
+        Parameters
+        ----------
+        filename : str or pathlib.Path
+            Output path; a ``.cif`` suffix is appended when absent.
+        with_edge_atoms : bool, optional
+            If ``True``, write both node and edge-center atoms; if
+            ``False`` (default), write only nodes and connect them
+            directly through the edge midpoints.
+        *args, **kwargs
+            Forwarded to the underlying ``_write_cif_*`` helper (e.g.
+            ``scale``).
         """
         path = Path(filename).resolve()
         if not path.parent.exists():
@@ -260,6 +624,21 @@ class Topology:
             os.remove(str(path))
 
     def _write_cif_with_edge_atoms(self, path, scale=1.0):
+        """Write a CIF containing both node and edge-center atoms.
+
+        Emits every slot (nodes and edge-centers) as an atom and records
+        each node-to-edge-center bond, with periodic image labels for
+        bonds that cross the cell boundary. Used by ``write_cif`` when
+        ``with_edge_atoms=True``.
+
+        Parameters
+        ----------
+        path : pathlib.Path
+            Resolved output path (already suffixed ``.cif``).
+        scale : float, optional
+            Multiplier applied to cell lengths and bond distances
+            (default ``1.0``).
+        """
         # stem = path.stem.replace(" ", "_")
 
         with path.open("w") as f:
@@ -302,11 +681,13 @@ class Topology:
             f.write("_atom_type_partial_charge\n")
 
             def tag2symbol(tag):
+                """Map a slot tag to a distinct chemical symbol."""
                 # 57: atomic number of the first lanthanide element.
                 # 7: Nitrogen.
                 return ase.Atom(tag + 7).symbol
 
             def tags2symbols(tags):
+                """Map a sequence of slot tags to chemical symbols."""
                 return [tag2symbol(tag) for tag in tags]
 
             tags = self.atoms.get_tags()
@@ -372,6 +753,28 @@ class Topology:
                     )
 
     def _write_cif_without_edge_atoms(self, path, scale=1.0):
+        """Write a CIF containing only node atoms.
+
+        Emits just the node (vertex) slots and connects each pair of
+        nodes that share an edge-center directly, doubling the
+        node-to-edge displacement to span the full node-node bond and
+        labeling periodic images as needed. Used by ``write_cif`` when
+        ``with_edge_atoms=False``.
+
+        Parameters
+        ----------
+        path : pathlib.Path
+            Resolved output path (already suffixed ``.cif``).
+        scale : float, optional
+            Multiplier applied to cell lengths and bond distances
+            (default ``1.0``).
+
+        Raises
+        ------
+        Exception
+            If an edge-center's reciprocal node neighbor cannot be matched
+            while reconstructing node-node bonds.
+        """
         # stem = path.stem.replace(" ", "_")
 
         with path.open("w") as f:
@@ -414,11 +817,13 @@ class Topology:
             f.write("_atom_type_partial_charge\n")
 
             def tag2symbol(tag):
+                """Map a slot tag to a distinct chemical symbol."""
                 # 57: atomic number of the first lanthanide element.
                 # 7: Nitrogen.
                 return ase.Atom(tag + 7).symbol
 
             def tags2symbols(tags):
+                """Map a sequence of slot tags to chemical symbols."""
                 return [tag2symbol(tag) for tag in tags]
 
             node_indices = self.node_indices
@@ -499,6 +904,25 @@ class Topology:
                     )
 
     def __mul__(self, m):
+        """Return a supercell of this net replicated along the cell axes.
+
+        Multiplies the underlying ``ase.Atoms`` to tile the net, carries
+        each slot's coordination number over to the replicated slots, and
+        rebuilds all derived properties on the new (larger) topology.
+        Useful for generating frameworks bigger than the primitive net.
+        The original topology is left unchanged.
+
+        Parameters
+        ----------
+        m : int or sequence of int
+            Repetition along the cell vectors, in any form ``ase.Atoms``
+            multiplication accepts (e.g. ``2`` or ``(2, 2, 1)``).
+
+        Returns
+        -------
+        Topology
+            A new topology representing the requested supercell.
+        """
         atoms = self.atoms.copy()
 
         old_cn = atoms.info["cn"]
@@ -520,15 +944,48 @@ class Topology:
         return new_topology
 
     def __rmul__(self, m):
+        """Return a supercell, supporting ``m * topology`` ordering.
+
+        Parameters
+        ----------
+        m : int or sequence of int
+            Repetition along the cell vectors; see ``__mul__``.
+
+        Returns
+        -------
+        Topology
+            The same supercell ``__mul__`` would produce.
+        """
         return self * m
 
     def describe(
         self, symmetry_edge_type=False, slot_info=False, file=sys.stdout
     ):
+        """Print a human-readable summary of the net's structure.
+
+        Writes a formatted report covering the net name and space group,
+        slot/type counts, the slot indices grouped by node type and by
+        edge type, and optionally a symmetry-based edge grouping and a
+        per-slot listing. Intended as a quick, readable inventory of what
+        the net offers when choosing building-block assignments.
+
+        Parameters
+        ----------
+        symmetry_edge_type : bool, optional
+            If ``True``, also print edges grouped by their symmetry-based
+            (single negative-tag) type. Default ``False``.
+        slot_info : bool, optional
+            If ``True``, also print a line per slot with its type and
+            adjacent slots. Default ``False``.
+        file : file-like, optional
+            Destination stream for the report (default ``sys.stdout``).
+        """
         def comma_numbers(nums):
+            """Join numbers into a comma-separated string."""
             return ", ".join([str(n) for n in nums])
 
         def split_list(l, size):
+            """Chunk a list into sublists of at most ``size`` items."""
             out = []
             inner = []
             for e in l:

--- a/src/pormake/utils.py
+++ b/src/pormake/utils.py
@@ -1,3 +1,18 @@
+"""I/O and geometry helpers shared across the PORMAKE pipeline.
+
+This module collects the low-level utilities that translate between the
+file formats PORMAKE consumes (``.cgd`` nets, building-block ``.xyz``
+files) and the in-memory :class:`ase.Atoms` representation, plus small
+geometric helpers used during assembly and a CIF writer for individual
+molecules.
+
+It also defines the module-level constant ``METAL_LIKE``: a list of
+element symbols treated as "metal-like". It is used elsewhere to detect
+which nodes correspond to metal clusters when classifying building
+blocks, since metal nodes and organic linkers play different roles in a
+Metal-Organic Framework.
+"""
+
 from pathlib import Path
 
 import ase
@@ -106,8 +121,25 @@ METAL_LIKE = [
 
 
 def bound_values(x, eps=1e-4):
-    """
-    Add description.
+    """Nudge fractional coordinates away from the exact cell boundary.
+
+    Values that sit essentially at 0 or 1 are pushed inward by ``eps``.
+    Fractional coordinates lying exactly on a periodic boundary cause
+    ambiguous wrapping and edge-case artifacts when neighbor lists are
+    rebuilt, so this clamp keeps positions strictly inside ``(0, 1)``.
+
+    Parameters
+    ----------
+    x : numpy.ndarray
+        Array of fractional coordinates.
+    eps : float, optional
+        Minimum distance to keep from the 0 and 1 boundaries.
+
+    Returns
+    -------
+    numpy.ndarray
+        Coordinates with values near 0 replaced by ``eps`` and values
+        near 1 replaced by ``1 - eps``.
     """
     x = np.where(np.abs(x - 0) < eps, np.full_like(x, 0 + eps), x)
     x = np.where(np.abs(x - 1) < eps, np.full_like(x, 1 - eps), x)
@@ -118,6 +150,32 @@ def bound_values(x, eps=1e-4):
 def covalent_neighbor_list(
     atoms, scale=1.2, neglected_species=[], neglected_indices=[]
 ):
+    """Build a bonded neighbor list from scaled covalent radii.
+
+    Wraps :func:`ase.neighborlist.neighbor_list` using per-atom cutoffs
+    derived from ASE's natural (covalent) radii, scaled by ``scale`` so
+    that atoms within roughly bonding distance are treated as
+    neighbors. Selected species or indices can be excluded from bonding
+    by zeroing their cutoff, which is useful for ignoring connection
+    markers or specific atoms when inferring molecular bonds.
+
+    Parameters
+    ----------
+    atoms : ase.Atoms
+        Atoms to analyze.
+    scale : float, optional
+        Multiplier applied to each natural cutoff radius.
+    neglected_species : list of str, optional
+        Element symbols whose atoms should not form bonds.
+    neglected_indices : list of int, optional
+        Atom indices that should not form bonds.
+
+    Returns
+    -------
+    tuple of numpy.ndarray
+        The ``("ijD")`` neighbor-list arrays: first-atom indices,
+        second-atom indices, and the distance vectors between them.
+    """
     cutoffs = natural_cutoffs(atoms)
     cutoffs = [scale * c for c in cutoffs]
     # Remove radii to neglect them.
@@ -132,8 +190,35 @@ def covalent_neighbor_list(
 
 
 def read_cgd(filename, node_symbol="C", edge_center_symbol="O"):
-    """
-    Read cgd format and return topology as ase.Atoms object.
+    """Parse a ``.cgd`` net file into an :class:`ase.Atoms` topology.
+
+    A ``.cgd`` file describes an abstract net by its space group, cell
+    parameters, symmetry-unique node positions (with coordination
+    numbers), and edges. This function expands the asymmetric unit by
+    the space group via :mod:`pymatgen`, places a placeholder atom at
+    every node and edge center, removes symmetry-generated duplicates,
+    and returns the result as an :class:`ase.Atoms` object that the rest
+    of PORMAKE treats as the topology skeleton.
+
+    Nodes are tagged with non-negative ``type`` values and edge centers
+    with negative ones, and each site carries its coordination number
+    ``cn`` so building blocks can later be matched by connectivity.
+
+    Parameters
+    ----------
+    filename : str or pathlib.Path
+        Path to the ``.cgd`` net file.
+    node_symbol : str, optional
+        Element symbol used as a placeholder for net nodes.
+    edge_center_symbol : str, optional
+        Element symbol used as a placeholder for edge centers.
+
+    Returns
+    -------
+    ase.Atoms
+        The topology, with ``tags`` encoding site types and ``info``
+        holding the space group, name, and per-site coordination
+        numbers.
     """
     with open(filename, "r") as f:
         # Neglect "CRYSTAL" and "END"
@@ -264,6 +349,34 @@ def read_cgd(filename, node_symbol="C", edge_center_symbol="O"):
 
 
 def read_budiling_block_xyz(bb_file):
+    """Parse a building-block ``.xyz`` file into an :class:`ase.Atoms`.
+
+    Reads an extended ``.xyz`` describing a molecular building block:
+    each atom line carries an element symbol, Cartesian position, and an
+    optional partial charge. Dummy ``"X"`` atoms mark the connection
+    points where the fragment attaches to neighboring blocks, and their
+    indices are recorded so the assembly step can align them onto a
+    topology slot. Any lines beyond the atom block are parsed as bonds
+    (atom-index pairs plus a bond type) for CIF export.
+
+    Parameters
+    ----------
+    bb_file : str or pathlib.Path
+        Path to the building-block ``.xyz`` file.
+
+    Returns
+    -------
+    ase.Atoms
+        The building block, whose ``info`` dict holds the connection
+        point indices (``"cpi"``), name, and optional ``bonds`` and
+        ``bond_types``. Per-atom partial charges are stored as the
+        atoms' initial charges.
+
+    Notes
+    -----
+    The misspelled function name (``budiling``) is intentional and kept
+    for backward compatibility.
+    """
     name = Path(bb_file).stem
 
     with open(bb_file, "r") as f:
@@ -322,17 +435,29 @@ def read_budiling_block_xyz(bb_file):
 
 
 def write_molecule_cif(filename, atoms, bond_pairs, bond_types):
-    """
-    Write cif for the molecule structures.
+    """Write a single molecule to a P1 CIF file with bonds.
 
-    Args:
-        filename: file name.
-        atoms: ase.Atoms object.
-        bond_pairs: list of bond paris. contains (i, j).
-        bond_types: list of bond types. contains one of "S", "D", "T", "A".
+    Places the molecule, centered on its center of mass, inside a cubic
+    ``P1`` cell sized to comfortably enclose it, then writes fractional
+    coordinates, partial charges, and the supplied bond list. This is
+    used to export an individual building block or fragment for
+    inspection in crystallographic viewers.
 
-    Returns:
-        None
+    Parameters
+    ----------
+    filename : str or pathlib.Path
+        Output path; a ``.cif`` suffix is enforced.
+    atoms : ase.Atoms
+        The molecule to write.
+    bond_pairs : list of tuple of int
+        Bonded atom-index pairs ``(i, j)``.
+    bond_types : list of str
+        Bond type for each pair, one of ``"S"``, ``"D"``, ``"T"``, or
+        ``"A"`` (single, double, triple, aromatic).
+
+    Returns
+    -------
+    None
     """
 
     path = Path(filename).resolve()


### PR DESCRIPTION
## Summary
- `src/pormake`의 모든 모듈·클래스·메서드·property·중첩 헬퍼에 영어 NumPy 스타일 docstring 추가
- 구현 재진술이 아니라 build 파이프라인(topology → building block → locate → scale → framework) 안에서 각 객체가 **왜 존재하고 어떻게 쓰이는지** 고차원 의미 중심으로 작성
- `bound_values`의 `Add description.` placeholder 교체, 남아있던 Google 스타일(`Args:`/`Return:`)을 NumPy 스타일로 통일, experimental decomposer docstring 정리
- **docstring만 변경, 실행 코드 불변**

## Verification
- AST 비교: docstring 제거 후 13개 파일 모두 바이트 동일 (로직/시그니처/import 불변)
- `uv run pytest`: **131 passed** (기존과 동일)
- AST 커버리지 워크: 모듈·클래스·함수·중첩 헬퍼 전부 docstring 보유
- 추가된 라인 80칼럼 초과 없음

Closes #52

## Test plan
- [x] 전체 테스트 통과 (`uv run pytest -q`)
- [x] 패키지 및 experimental decomposer import 확인
- [x] docstring-only diff 확인 (AST 동등성)