### PR TITLE
ci: add tag-triggered PyPI auto-publish workflow (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release to PyPI
+
+on:
+  push:
+    tags:
+      - "v*" # v로 시작하는 모든 태그 (v0.2.3, v1.0.0 ...)
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC Trusted Publishing에 필수 (이게 빠지면 인증 실패)
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv and Python 3.12
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify tag matches pyproject version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PROJ_VERSION=$(uv version --short)
+          echo "tag=$TAG_VERSION  project=$PROJ_VERSION"
+          if [ "$TAG_VERSION" != "$PROJ_VERSION" ]; then
+            echo "::error::tag($TAG_VERSION)와 pyproject.toml version($PROJ_VERSION)이 일치하지 않습니다."
+            exit 1
+          fi
+
+      - name: Build
+        run: uv build
+
+      - name: Publish to PyPI (Trusted Publishing)
+        run: uv publish


### PR DESCRIPTION
## 요약

`v*` 태그를 push하면 PyPI에 자동 배포하는 GitHub Actions 워크플로(`release.yml`)를 추가한다. 법인 가이드 "[개발] uv로 PyPI 라이브러리 배포 + GitHub Actions tag 자동화"의 Trusted Publishing(OIDC) 방식을 따른다.

## 동작

- **트리거**: `on.push.tags: ["v*"]`
- **인증**: OIDC Trusted Publishing — API 토큰 불필요 (`permissions.id-token: write`)
- **environment 미지정**: PyPI Trusted Publisher 등록 정보(환경 없음)와 일치
- **버전 가드**: 배포 전 태그 ↔ `pyproject.toml` `version` 일치 검증. 불일치 시 job 실패 → 배포 차단
- **빌드/배포**: `uv build` → `uv publish`
- 기존 `test.yaml`과 동일하게 `astral-sh/setup-uv@v5` 사용

## 릴리스 방법

```bash
uv version 0.2.3
git add pyproject.toml && git commit -m "release: v0.2.3"
git tag v0.2.3
git push && git push origin v0.2.3
# 이후 Actions가 자동 build & publish
```

## 검증

- 로컬 YAML 파싱 통과 (pyyaml)
- `permissions.id-token: write` 확인, `environment` 키 부재 확인
- 스텝 순서: checkout → setup-uv → verify version → build → publish

Closes #58
