### PR TITLE
chore(release): v0.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pormake"
-version = "0.2.2"
+version = "0.2.3"
 description = "Python library for the construction of porous materials using topology and building blocks"
 license = "MIT"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1742,7 +1742,7 @@ wheels = [
 
 [[package]]
 name = "pormake"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "ase" },


### PR DESCRIPTION
## 요약
PyPI 릴리스 v0.2.3을 위한 버전 bump.

0.2.2 → 0.2.3 (패치). 0.2.2 이후 변경은 docs(README per-slot linker, NumPy docstrings) + CI(tag 기반 자동 배포 워크플로)뿐이다.

머지 후 `v0.2.3` 태그를 push하면 `release.yml`이 OIDC Trusted Publishing으로 PyPI에 자동 배포한다.

- `pyproject.toml`: version 0.2.2 → 0.2.3
- `uv.lock`: pormake 0.2.2 → 0.2.3