### PR TITLE
docs: refresh outdated README info and add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,73 @@
+# Changelog
+
+All notable changes to **PORMAKE** are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Documented per-slot linker assignment for edges in the README: edge slots that
+  share an edge type are not locked together, so individual edge slots can be
+  given different linkers. ([#57])
+
+## [0.2.3] - 2026-05-30
+
+### Fixed
+- Relaxed the `pymatgen` dependency constraint by removing the `< 2024.0.0` upper
+  bound (now `pymatgen >= 2023.8.10`). This resolves the unsatisfiable dependency
+  set on Python 3.12, where `pymatgen >= 2024` is required. ([#36])
+
+### Added
+- NumPy-style docstrings across `src/pormake`.
+- A comprehensive `pytest` test suite (unit, integration, and smoke tests) running
+  on a CI matrix of Python 3.10–3.12 on Ubuntu and macOS.
+- Tag-based PyPI publishing via GitHub Actions using OIDC Trusted Publishing:
+  pushing a `v*` tag builds and publishes the release with no API token. ([#58], [#59])
+
+### Changed
+- Migrated project management from `poetry` to `uv`.
+- Dropped support for Python 3.8 and 3.9; the minimum supported version is now
+  Python 3.10.
+- Routine dependency updates via Dependabot.
+
+## [0.2.2] - 2024-06-27
+
+_Released on PyPI. This release predates the changelog — see the
+[commit history](https://github.com/Sangwon91/PORMAKE/commits/main) for details._
+
+## [0.2.1] - 2024-01-13
+
+### Added
+- Building blocks with partial charge. Thanks to [@aniruddha-seal](https://github.com/aniruddha-seal)!
+
+## [0.2.0] - 2023-09-24
+
+### Added
+- A module for extracting building blocks from MOFs (MOF Decomposer).
+
+## [0.1.2] - 2023-09-07
+
+_Released on PyPI._
+
+## [0.1.1] - 2022-12-31
+
+_Released on PyPI._
+
+## [0.1.0] - 2022-12-31
+
+- Initial public release on PyPI.
+
+[Unreleased]: https://github.com/Sangwon91/PORMAKE/compare/v0.2.3...HEAD
+[0.2.3]: https://pypi.org/project/pormake/0.2.3/
+[0.2.2]: https://pypi.org/project/pormake/0.2.2/
+[0.2.1]: https://pypi.org/project/pormake/0.2.1/
+[0.2.0]: https://pypi.org/project/pormake/0.2.0/
+[0.1.2]: https://pypi.org/project/pormake/0.1.2/
+[0.1.1]: https://pypi.org/project/pormake/0.1.1/
+[0.1.0]: https://pypi.org/project/pormake/0.1.0/
+[#36]: https://github.com/Sangwon91/PORMAKE/issues/36
+[#57]: https://github.com/Sangwon91/PORMAKE/pull/57
+[#58]: https://github.com/Sangwon91/PORMAKE/issues/58
+[#59]: https://github.com/Sangwon91/PORMAKE/pull/59

--- a/README.md
+++ b/README.md
@@ -5,14 +5,21 @@
 >
 > [Please cite me if you find it useful!](https://pubs.acs.org/doi/abs/10.1021/acsami.1c02471)
 
-Development Roadmap (updated 2024.12.20):
-1. Change of project management tool: `poetry` to `uv`
-1. Simple web application for the generation of porous materials
-1. Enrich the code with descriptive docstrings.
-1. Fortify the project by implementing comprehensive test code.
-1. Development of an enhanced algorithm for improved placement of edge building blocks (considering symmetry).
+Development Roadmap (updated 2026.05):
+- [x] Change of project management tool: `poetry` to `uv`
+- [ ] Simple web application for the generation of porous materials
+- [x] Enrich the code with descriptive docstrings (NumPy-style docstrings across `src/pormake`)
+- [x] Fortify the project by implementing comprehensive test code (`pytest` unit, integration, and smoke tests)
+- [ ] Development of an enhanced algorithm for improved placement of edge building blocks (considering symmetry)
 
 ## Release Note
+
+See [CHANGELOG.md](./CHANGELOG.md) for the full version history.
+
+#### Version: `0.2.3`
+
+**Fixed**: relaxed the `pymatgen` version constraint (removed the `<2024.0.0` upper bound), resolving installation conflicts on Python 3.12 ([#36](https://github.com/Sangwon91/PORMAKE/issues/36)). This release also adds NumPy-style docstrings, a `pytest` test suite, and automated PyPI releases via GitHub Actions.
+
 #### New fork
 [Repository URL](https://github.com/geonho42/PORMAKE)
 
@@ -565,7 +572,7 @@ bb = pm.BuildingBlock('N10.xyz')
 ```
 
 ## Contributions
-This project is managed through [`uv`](https://docs.astral.sh/uv/). It is strongly recommended to use `uv` for development. Additionally, support for Python versions below `3.10` will be discontinued in the future, so it is recommended to use Python `3.10` or higher. Below are examples of commands used when developing with `uv`.
+This project is managed through [`uv`](https://docs.astral.sh/uv/). It is strongly recommended to use `uv` for development. Additionally, support for Python versions below `3.10` has been discontinued, so Python `3.10` or higher is required. Below are examples of commands used when developing with `uv`.
 
 ### 1. Install required libraries
 ```bash
@@ -576,7 +583,10 @@ uv sync
 
 ### 2. Apply pre-commit before commit
 ```bash
-uvx pre-commit
+# Install the git hook so checks run automatically on every commit.
+uvx pre-commit install
+# (optional) run all hooks against the whole repository once.
+uvx pre-commit run --all-files
 ```
 
 ### 3. Install new libraries for new functionalities


### PR DESCRIPTION
## 요약

오래된 README 정보를 갱신하고, 루트에 `CHANGELOG.md`를 추가한다.

## README 변경

- **Development Roadmap**: 날짜 `2024.12.20` → `2026.05`, 번호 목록 → 체크리스트. 완료 항목(`poetry`→`uv` 전환, NumPy-style docstring, `pytest` 테스트 스위트)을 ✅ 표시. (web 앱·엣지 배치 알고리즘은 미완 — 실제로 web 앱 파일 없음)
- **Release Note**: `CHANGELOG.md` 링크 추가 + `0.2.3` 항목(pymatgen 상한 제거로 Python 3.12 충돌 해결, [#36](https://github.com/Sangwon91/PORMAKE/issues/36)) 추가.
- **Contributions**: "Python 3.10 미만 지원 *중단 예정*" → "*이미 중단됨, 3.10+ 필수*" (현재 `requires-python = ">=3.10"`과 일치).
- **pre-commit**: `uvx pre-commit`(서브커맨드 없어 실패) → `uvx pre-commit install` + `run --all-files`.

## CHANGELOG.md (신규)

[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 형식 + SemVer. `Unreleased`(per-slot 엣지 링커 문서, [#57](https://github.com/Sangwon91/PORMAKE/pull/57)) + `0.2.3` 상세(Fixed/Added/Changed) + 이전 버전. 0.2.3·0.2.1·0.2.0은 검증된 내용, **0.2.2/0.1.x는 추정 없이 PyPI 릴리스 날짜만** 표기.

## 범위

문서만 변경 — 코드/빌드 영향 없음.
